### PR TITLE
Adding webfont build chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "dist"]
+	path = dist
+	url = https://github.com/bollwyvl/FiraCode.git
+	branch = gh-pages

--- a/jade/index.jade
+++ b/jade/index.jade
@@ -1,0 +1,14 @@
+doctype html
+html
+  head
+    style.
+      @import url("css/FiraCode.css");
+      
+      code, pre {
+        font-family: "FiraCode-Regular";
+      }
+      
+  body
+    h1 Fira Code: monospaced font with programming ligatures
+    pre
+      include ../firacode_showcase.txt

--- a/jade/index.jade
+++ b/jade/index.jade
@@ -3,12 +3,84 @@ html
   head
     style.
       @import url("css/FiraCode.css");
+      @import url("https://cdn.jsdelivr.net/g/codemirror(codemirror.css+theme/monokai.css)");
       
-      code, pre {
+      .CodeMirror {
         font-family: "FiraCode-Regular";
+        text-rendering: optimizeLegibility;
+        -webkit-font-variant-ligatures: common-ligatures;
+        font-variant-ligatures: common-ligatures;
+      }
+      .CodeMirror {
+        height: auto;
       }
       
   body
     h1 Fira Code: monospaced font with programming ligatures
-    pre
-      include ../firacode_showcase.txt
+    
+    input(type="checkbox")
+    | Show Ligatures
+    
+    h2 JavaScript
+    textarea.javascript.
+      x == 0
+      el === document.body
+      true != false
+      true !== false
+      n >= 0
+      i <= Integer.MAX_INT
+      A.id <> NULL
+      true <=> false
+    
+    h2 Erlang
+    textarea.erlang.
+      if L !== [] -> % Is L is not empty
+          sum(L) / count(L);
+      true -->
+          error
+      end.
+          
+      -spec foo(integer())) -> integer().
+      foo(X) -> 1 + X
+      
+      text(Foo)-->Foo.
+      
+      qsort1([H | T)]) ->
+             qsort1([ X || x <- T, X < H ]) ++ [H] ++ qsort([ X || X <- T, X  H ]).
+
+    h2 go
+    textarea.go.
+      func main() {
+        ch := make(chan int)
+        ch <- 1.0e10 // magic number
+        x, ok := <- ch
+        ok = true
+        defer fmt.Println(`exittingnow\`)
+        go println(le("hello world!"))
+        return
+      }
+      
+    h2 ruby
+    textarea.ruby.
+      class Car < ActiveRecord::Base
+        has_many :wheels, :class_name => 'Wheel', :foreign_key => 'car_id'
+        scope :available, -> { where(available: true) }
+      end
+      omega = -> { 'alpha' }
+      alpha = ->(arg) { arg*2 }
+      hash = {1 => 'one', 2 => 'two'}
+    
+    script(
+      src="https://cdn.jsdelivr.net/g/codemirror(codemirror.js+mode/javascript/javascript.js+mode/ruby/ruby.js+mode/haskell/haskell.js+mode/go/go.js+mode/ruby/ruby.js)"
+    )
+    
+    script.
+      ["javascript", "erlang", "go", "ruby"].map(function(lang){
+        CodeMirror.fromTextArea(
+          document.querySelector("." + lang),
+          {
+            theme: "monokai",
+            mode: lang
+          }
+        );
+      })

--- a/jade/index.jade
+++ b/jade/index.jade
@@ -1,86 +1,109 @@
 doctype html
 html
   head
+    meta(name="viewport"
+         content="width=device-width, initial-scale=1.0")
     style.
       @import url("css/FiraCode.css");
-      @import url("https://cdn.jsdelivr.net/g/codemirror(codemirror.css+theme/monokai.css)");
+      @import url("https://cdn.jsdelivr.net/g/codemirror(codemirror.css+theme/elegant.css),octicons,primer");
       
       .CodeMirror {
         font-family: "FiraCode-Regular";
+        height: auto;
+        margin-bottom: 10px;
+      }
+      
+      .show-ligatures .CodeMirror {
         text-rendering: optimizeLegibility;
         -webkit-font-variant-ligatures: common-ligatures;
         font-variant-ligatures: common-ligatures;
       }
-      .CodeMirror {
-        height: auto;
+      
+      .toggle-ligatures-label {
+        color: #777;
+      }
+      .show-ligatures .toggle-ligatures-label {
+        color: #000;
       }
       
-  body
-    h1 Fira Code: monospaced font with programming ligatures
-    
-    input(type="checkbox")
-    | Show Ligatures
-    
-    h2 JavaScript
-    textarea.javascript.
-      x == 0
-      el === document.body
-      true != false
-      true !== false
-      n >= 0
-      i <= Integer.MAX_INT
-      A.id <> NULL
-      true <=> false
-    
-    h2 Erlang
-    textarea.erlang.
-      if L !== [] -> % Is L is not empty
-          sum(L) / count(L);
-      true -->
-          error
-      end.
-          
-      -spec foo(integer())) -> integer().
-      foo(X) -> 1 + X
-      
-      text(Foo)-->Foo.
-      
-      qsort1([H | T)]) ->
-             qsort1([ X || x <- T, X < H ]) ++ [H] ++ qsort([ X || X <- T, X  H ]).
+  body.show-ligatures
+    .container
+      h1: a(href="https://github.com/tonsky/FiraCode") Fira Code
+      h2 monospaced font 
+        input.toggle-ligatures(type="checkbox", checked)
+        span.toggle-ligatures-label  with programming ligatures
 
-    h2 go
-    textarea.go.
-      func main() {
-        ch := make(chan int)
-        ch <- 1.0e10 // magic number
-        x, ok := <- ch
-        ok = true
-        defer fmt.Println(`exittingnow\`)
-        go println(le("hello world!"))
-        return
-      }
-      
-    h2 ruby
-    textarea.ruby.
-      class Car < ActiveRecord::Base
-        has_many :wheels, :class_name => 'Wheel', :foreign_key => 'car_id'
-        scope :available, -> { where(available: true) }
-      end
-      omega = -> { 'alpha' }
-      alpha = ->(arg) { arg*2 }
-      hash = {1 => 'one', 2 => 'two'}
+      .columns
+        h3.one-fifth.column JavaScript
+        .four-fifths.column
+          textarea.javascript.
+            x == 0
+            el === document.body
+            true != false
+            true !== false
+            n >= 0
+            i <= Integer.MAX_INT
+            A.id <> NULL
+            true <=> false
+
+        h3.one-fifth.column Erlang
+        .four-fifths.column
+          textarea.erlang.
+            if L !== [] -> % Is L is not empty
+                sum(L) / count(L);
+            true -->
+                error
+            end.
+                
+            -spec foo(integer())) -> integer().
+            foo(X) -> 1 + X
+            
+            text(Foo)-->Foo.
+            
+            qsort1([H | T)]) ->
+                   qsort1([ X || x <- T, X < H ]) ++ [H] ++ qsort([ X || X <- T, X  H ]).
+
+        h3.one-fifth.column go
+        .four-fifths.column
+          textarea.go.
+            func main() {
+              ch := make(chan int)
+              ch <- 1.0e10 // magic number
+              x, ok := <- ch
+              ok = true
+              defer fmt.Println(`exittingnow\`)
+              go println(le("hello world!"))
+              return
+            }
+
+        h3.one-fifth.column ruby
+        .four-fifths.column
+          textarea.ruby.
+            class Car < ActiveRecord::Base
+              has_many :wheels, :class_name => 'Wheel', :foreign_key => 'car_id'
+              scope :available, -> { where(available: true) }
+            end
+            omega = -> { 'alpha' }
+            alpha = ->(arg) { arg*2 }
+            hash = {1 => 'one', 2 => 'two'}
     
     script(
       src="https://cdn.jsdelivr.net/g/codemirror(codemirror.js+mode/javascript/javascript.js+mode/ruby/ruby.js+mode/haskell/haskell.js+mode/go/go.js+mode/ruby/ruby.js)"
     )
     
     script.
-      ["javascript", "erlang", "go", "ruby"].map(function(lang){
-        CodeMirror.fromTextArea(
-          document.querySelector("." + lang),
-          {
-            theme: "monokai",
-            mode: lang
-          }
-        );
-      })
+      ;(function(){
+        ["javascript", "erlang", "go", "ruby"].map(function(lang){
+          CodeMirror.fromTextArea(
+            document.querySelector("." + lang),
+            {
+              mode: lang
+            }
+          );
+        });
+        
+        var toggle = document.querySelector(".toggle-ligatures");
+        toggle.onchange = function(){
+          document.body.classList.toggle('show-ligatures');
+        }
+      }).call();

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "eot": "./node_modules/.bin/ttf2eot FiraCode-Regular.ttf dist/fonts/FiraCode-Regular.eot",
     "svg": "./node_modules/.bin/ttf2svg FiraCode-Regular.ttf && mv FiraCode-Regular.svg dist/fonts/",
     "sass": "./node_modules/.bin/node-sass ./scss/FiraCode.scss  -o dist/css/",
-    "build": "npm run clean && npm run cp && npm run woff && npm run eot && npm run svg && npm run sass"
+    "jade": "./node_modules/.bin/jade jade/*.jade -o dist/",
+    "build": "npm run clean && npm run cp && npm run woff && npm run eot && npm run svg && npm run sass && npm run jade"
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,7 @@
     "ttf2woff": "~1.3.0",
     "ttf2svg": "0.0.7",
     "ttf2eot": "~1.3.0",
-    "node-sass": "~3.1.2"
+    "node-sass": "~3.1.2",
+    "jade": "~1.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "FiraCode",
+  "version": "0.0.0",
+  "description": "Webfonts for FiraCode, with programming ligatures",
+  "main": "index.js",
+  "scripts": {
+    "clean": "rm -rf dist/* && mkdir -p dist/fonts",
+    "cp": "cp FiraCode-Regular.ttf dist/fonts/ && cp -r scss dist/",
+    "woff": "./node_modules/.bin/ttf2woff FiraCode-Regular.ttf dist/fonts/FiraCode-Regular.woff",
+    "eot": "./node_modules/.bin/ttf2eot FiraCode-Regular.ttf dist/fonts/FiraCode-Regular.eot",
+    "svg": "./node_modules/.bin/ttf2svg FiraCode-Regular.ttf && mv FiraCode-Regular.svg dist/fonts/",
+    "sass": "./node_modules/.bin/node-sass ./scss/FiraCode.scss  -o dist/css/",
+    "build": "npm run clean && npm run cp && npm run woff && npm run eot && npm run svg && npm run sass"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tonsky/FiraCode"
+  },
+  "author": "",
+  "license": "BSD",
+  "bugs": {
+    "url": "https://github.com/tonsky/FiraCode/issues"
+  },
+  "devDependencies": {
+    "ttf2woff": "~1.3.0",
+    "ttf2svg": "0.0.7",
+    "ttf2eot": "~1.3.0",
+    "node-sass": "~3.1.2"
+  }
+}

--- a/scss/FiraCode.scss
+++ b/scss/FiraCode.scss
@@ -1,0 +1,15 @@
+$firacode-font-path: "../fonts";
+
+@each $font-face in "FiraCode-Regular" {
+  @font-face {
+    font-family: $font-face, monospace;
+    font-style: normal;
+    font-weight: normal;
+    src: url('#{$firacode-font-path}/#{$font-face}.eot');
+    src: url('#{$firacode-font-path}/#{$font-face}.eot?') format('eot'),
+         url('#{$firacode-font-path}/#{$font-face}.woff') format('woff'),
+         url('#{$firacode-font-path}/#{$font-face}.ttf') format('truetype'),
+         url('#{$firacode-font-path}/#{$font-face}.svg') format('svg');
+  }
+}
+

--- a/scss/FiraCode.scss
+++ b/scss/FiraCode.scss
@@ -2,7 +2,7 @@ $firacode-font-path: "../fonts";
 
 @each $font-face in "FiraCode-Regular" {
   @font-face {
-    font-family: $font-face, monospace;
+    font-family: $font-face;
     font-style: normal;
     font-weight: normal;
     src: url('#{$firacode-font-path}/#{$font-face}.eot');


### PR DESCRIPTION
Great little font! I wanted to try it out in the IPython Notebook.

This proposes a NodeJS-based build chain. Basically, it's `npm install && npm run build` and you get:
- svg
- eot
- woff
- css
- scss (could easily add others, like less/stylus)
- sample html

I've taken cues from Font-Awesome, etc.

It uses the "gh-pages as submodule" approach, so there's a demo here:
http://bollwyvl.github.io/FiraCode/

The process could be entirely automated on travis-ci, so that any push to master would trigger this build, so you wouldn't even have to have node!