### PR TITLE
Clarify how to enable ligatures for BBEdit

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Do work:
 - TextMate 2
 - QtCreator
 - LightTable ([instructions](https://github.com/LightTable/LightTable/issues/1459#issuecomment-57366504))
-- BBEdit ([instructions](https://github.com/i-tu/Hasklig/issues/3#issue-46601683))
+- BBEdit — enter this command in a terminal to enable ligatures:  
+  `defaults write com.barebones.bbedit "EnableFontLigatures_Fira Code" -bool YES`
 - RStudio
 - Chocolat
 


### PR DESCRIPTION
Because Fira Code has a space in the family name, the instructions from Hasklig for how to enable ligatures in BBEdit aren't adequate.