### PR TITLE
Add Coda 2 to list of supported editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Do work:
   `defaults write com.barebones.bbedit "EnableFontLigatures_Fira Code" -bool YES`
 - RStudio
 - Chocolat
+- Coda 2
 
 Should work (copied from [Hasklig README](https://github.com/i-tu/Hasklig)):
 


### PR DESCRIPTION
Added Panic's Coda 2 (https://panic.com/coda/) to the list of supported editors.