### PR TITLE
Firacode works on KDE4 in some environments at least. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Do work:
 - RStudio
 - Chocolat
 - Kate, Konsole, KWrite in Plasma/KDE 5
+- Kate, Konsole, KWrite in KDE 4 using Debian Jessie or OS X
 
 
 Should work (copied from [Hasklig README](https://github.com/i-tu/Hasklig)):


### PR DESCRIPTION
 http://i.imgur.com/WV9Tz1e.jpg
 http://i.imgur.com/FAOEjAQ.jpg

I've created an VM image for qemu/kvm available here:

http://www.simcop2387.info/debian-kde-font/

I'm unable to provide an image for OS X for obvious reasons but screenshots are provided