### PR TITLE
Add Mancy to "Editor support" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Do work:
 - Chocolat
 - Kate, Konsole, KWrite in Plasma/KDE 5
 - Kate, Konsole, KWrite in KDE 4 using Debian Jessie or OS X
+- Mancy
 
 Should work (copied from [Hasklig README](https://github.com/i-tu/Hasklig)):
 


### PR DESCRIPTION
[Mancy](http://www.mancy-re.pl/) is a Electron based NodeJS REPL with Fira Code ligatures support. In fact, Mancy includes Fira Code font, so you can choose this font with no need to install by yourself.