### PR TITLE
Add Scratch to editor list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Work | Don’t work
 **Notepad** (Win) |
 **QtCreator** | 
 **RStudio** ([instructions](https://github.com/tonsky/FiraCode/wiki/RStudio-instructions)) |
+**Scratch** (elementary OS text editor) |
 **TextAdept** (Linux, Mac) |
 **TextMate 2** |
 **Visual Studio 2015** |


### PR DESCRIPTION
Scratch is the default text editor in elementary OS.