### PR TITLE
Update README.md with wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Programmers use a lot of symbols, often encoded with several characters. For the
 
 
 Fira Code is an extension of the Fira Mono font containing a set of ligatures for common programming multi-character combinations. This is just a font rendering feature: underlying code remains ASCII-compatible. This helps to read and understand code faster. For some frequent sequences like `..` or `//`, ligatures allow us to correct spacing.
+See detailed instructions on how to install the fonts in ([wiki](https://github.com/tonsky/FiraCode/wiki)).
 
 <img src="./showcases/all_ligatures.png" />
 


### PR DESCRIPTION
Though it seems obvious how to install the fonts in OS X, it wasn't that obvious for me. It'd be good to explicitly mention it. I added the link to the wiki page, cause I didn't find it right away when I was figuring out how to install it. Hopefully it'll help other people too.