### PR TITLE
Add mintty to the ligatures-unsupported list

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Works            | Doesn’t work
 **Konsole**      | **iTerm 2** ([coming in 3.1](https://gitlab.com/gnachman/iterm2/issues/3568#note_13118332))
 **QTerminal**    | **LXTerminal**
 **Terminal.app** (OS X default terminal) | **mate-terminal** 
-**Termux** (Android terminal emulator) | **PuTTY**
+**Termux** (Android terminal emulator) | **mintty**
+                 | **PuTTY**
                  | **rxvt**
                  | **Terminator, xfce4-terminal, lxterminal, gtkterm, xfce4-terminal** and other libvte-based terminals ([bug report](https://bugzilla.gnome.org/show_bug.cgi?id=584160))
                  | **sakura**


### PR DESCRIPTION
Mintty sadly does not support ligatures, and the unsupported list should have it listed.

(mintty is a (the?) VT100 terminal for Windows)

EDIT: Hold this! There may still be hope!

EDIT: There is only false hope. Definitely no support, even in the version that fixes some unicode stuff.