### PR TITLE
Add c9 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Clojure:
 | **Brackets** (with [this plugin](https://github.com/polo2ro/firacode-in-brackets)) | **gVim** |
 | **Chocolat** | **IDLE** |
 | **CLion** (2016.2+, [instructions](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions)) | **KDevelop 4** |
-| **Cloud9** | **Monkey Studio IDE** |
+| **Cloud9** ([instructions](https://github.com/tonsky/FiraCode/wiki/Cloud9-Instructions))| **Monkey Studio IDE** |
 | **Coda 2** | **Notepad++** |
 | **CodeLite** | **SublimeText** ([vote here](http://sublimetext.userecho.com/topic/1030059-does-sublimetext-support-programming-ligatures-fontlike-fira-code/)) |
 | **Eclipse** (Linux) |  |


### PR DESCRIPTION
- Wrote up a C9 instructions wiki page
- Updated README to link Cloud9 to instructions page.