### PR TITLE
Sublime Text supports ligature since 3146

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Swift:
 | **Chocolat** | **IDLE** |
 | **CLion** (2016.2+, [instructions](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions)) | **KDevelop 4** |
 | **Cloud9** ([instructions](https://github.com/tonsky/FiraCode/wiki/Cloud9-Instructions)) | **Monkey Studio IDE** |
-| **Coda 2** | **SublimeText** ([vote here](http://sublimetext.userecho.com/topic/1030059-does-sublimetext-support-programming-ligatures-fontlike-fira-code/)) |
-| **CodeLite** |  |
-| **Eclipse** (Mac 4.7+, Linux) |  |
+| **Coda 2** |
+| **CodeLite** |
+| **Eclipse** (Mac 4.7+, Linux) |
 | **Geany** |
 | **gEdit / Pluma** |
 | **GNOME Builder** |
@@ -111,6 +111,7 @@ Swift:
 | **RubyMine** (2016.2+, [instructions](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions)) |
 | **Scratch** |
 | **Spyder IDE** (only with Qt5) |
+| **SublimeText** (3146+) |
 | **TextAdept** (Linux, Mac) |
 | **TextEdit** |
 | **TextMate 2** |


### PR DESCRIPTION
http://www.sublimetext.com/3dev


BUILD 3146
6 October 2017

- Added Goto References when hovering over a symbol
- Added ligature support for symbols
- Various syntax highlighting improvements, including significant improvements for Makefiles, with thanks to Raoul Wols
- Windows: DirectWrite is now used by default for all fonts

![image](https://user-images.githubusercontent.com/6594915/31280623-825aec0e-aadf-11e7-9fa4-a89461fc2891.png)
