### PR TITLE
mintty works since v2.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,17 @@ Swift:
 | **Kitty**          | **ConEmu**         |
 | **Konsole**        | **GNOME Terminal** | 
 | **QTerminal**      | **mate-terminal**  |
-| **Terminal.app**   | **mintty**         |
-| **Termux**         | **PuTTY**          |
-| **Token2Shell/MD** | **rxvt**           |
-| **upterm**         | **ZOC** (Windows)  |
-| **ZOC** (macOS)    | **gtkterm, guake, LXTerminal, sakura, Terminator, xfce4-terminal,** and other libvte-based terminals ([bug report](https://bugzilla.gnome.org/show_bug.cgi?id=584160)) |
+| **Terminal.app**   | **PuTTY**          |
+| **Termux**         | **rxvt**           |
+| **Token2Shell/MD** | **ZOC** (Windows)  |
+| **upterm**         | **gtkterm, guake, LXTerminal, sakura, Terminator, xfce4-terminal,** and other libvte-based terminals ([bug report](https://bugzilla.gnome.org/show_bug.cgi?id=584160)) |
+| **ZOC** (macOS)    |                    |
+| **mintty** ([Fixed after v2.8.3](https://github.com/mintty/mintty/issues/601))|          |
+
+
+
+
+
 
 ### Editor support
 


### PR DESCRIPTION
I'm adding mintty to the works side of the table, linking with the relevant issue on mintty's side. 
![image](https://user-images.githubusercontent.com/988845/42267306-57c9fc4c-7f81-11e8-8202-98dafb560506.png)

Note:
-------
Although it is only partially supported, I thought it is worth mentioning. 