### PR TITLE
Change CDN links in Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ Swift:
 
 ```html
 <!-- HTML -->
-<link rel="stylesheet" href="https://cdn.rawgit.com/tonsky/FiraCode/1.206/distr/fira_code.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/tonsky/FiraCode@1.206/distr/fira_code.css">
 ```
 
 ```css
 /* CSS */
-@import url(https://cdn.rawgit.com/tonsky/FiraCode/1.206/distr/fira_code.css);
+@import url(https://cdn.jsdelivr.net/gh/tonsky/FiraCode@1.206/distr/fira_code.css);
 ```
 
 - IE 10+, Edge: enable with `font-feature-settings: "calt" 1;`


### PR DESCRIPTION
As Rawgit is closing example links will stop to function at the end of October 2019. I've chosen jsdelivr over unpkg as it's using GitHub as a source like Rawgit, rather than NPM, and have a bigger [market share](https://w3techs.com/technologies/comparison/cd-jsdelivr,cd-unpkg). Related issue #18.