### PR TITLE
Add goormIDE instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Swift:
 | **elementary Code** |  |
 | **Geany** |
 | **gEdit / Pluma** |
+| **GoormIDE** ([instructions](https://github.com/tonsky/FiraCode/wiki/GoormIDE-Instructions)) |
 | **GNOME Builder** |
 | **IntelliJ IDEA** (2016.2+, [instructions](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions)) |
 | **Kate, KWrite** |


### PR DESCRIPTION
- Wrote up a GoormIDE instructions wiki page ([link](https://github.com/tonsky/FiraCode/wiki/GoormIDE-Instructions))
- Updated README to link GoormIDE to instructions page. 