### PR TITLE
Add crosh (ChromeOS terminal) to Works list

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Swift:
 | Works              | Doesn’t work       |
 | ------------------ | ------------------ |
 | **Butterfly**      | **Alacritty**      |
-| **Crosh** (ChromeOS, [instructions](https://github.com/tonsky/FiraCode/wiki/ChromeOS-Terminal)) | **cmd.exe** |
+| **crosh** (ChromeOS, [instructions](https://github.com/tonsky/FiraCode/wiki/ChromeOS-Terminal)) | **cmd.exe** |
 | **Hyper.app**      | **Cmder**          |
 | **iTerm 2** ([3.1+](https://gitlab.com/gnachman/iterm2/issues/3568#note_13118332)) | **ConEmu** |
 | **Kitty**          | **GNOME Terminal** |

--- a/README.md
+++ b/README.md
@@ -60,15 +60,16 @@ Swift:
 | Works              | Doesn’t work       |
 | ------------------ | ------------------ |
 | **Butterfly**      | **Alacritty**      |
-| **Hyper.app**      | **cmd.exe**        |
-| **iTerm 2** ([3.1+](https://gitlab.com/gnachman/iterm2/issues/3568#note_13118332)) | **Cmder** |
-| **Kitty**          | **ConEmu**         |
-| **Konsole**        | **GNOME Terminal** | 
-| **mintty** (partial support [2.8.3+](https://github.com/mintty/mintty/issues/601))| **mate-terminal** |
-| **QTerminal**      | **PuTTY**          |
-| **Terminal.app**   | **rxvt**           |
-| **Termux**         | **ZOC** (Windows)  |
-| **Token2Shell/MD** | **gtkterm, guake, LXTerminal, sakura, Terminator, xfce4-terminal,** and other libvte-based terminals ([bug report](https://bugzilla.gnome.org/show_bug.cgi?id=584160)) |
+| **Crosh** (ChromeOS, [instructions](https://github.com/tonsky/FiraCode/wiki/ChromeOS-Terminal)) | **cmd.exe** |
+| **Hyper.app**      | **Cmder**          |
+| **iTerm 2** ([3.1+](https://gitlab.com/gnachman/iterm2/issues/3568#note_13118332)) | **ConEmu** |
+| **Kitty**          | **GNOME Terminal** |
+| **Konsole**        | **mate-terminal**  | 
+| **mintty** (partial support [2.8.3+](https://github.com/mintty/mintty/issues/601))| **PuTTY** |
+| **QTerminal**      | **rxvt**           |
+| **Terminal.app**   | **ZOC** (Windows)  |
+| **Termux**         | **gtkterm, guake, LXTerminal, sakura, Terminator, xfce4-terminal,** and other libvte-based terminals ([bug report](https://bugzilla.gnome.org/show_bug.cgi?id=584160)) |
+| **Token2Shell/MD** |
 | **upterm**         |
 | **ZOC** (macOS)    |
 


### PR DESCRIPTION
Was disappointed to find that Fira Code is not supported by crosh, based on this readme. In fact, it's not acknowledged at all, so I scoured the web for a solution - and found one in this repo's wiki.

In this PR I've added a new entry to the Works list in the Terminal section to include crosh, with a link to the page on the wiki with the installation instructions.

Tested as working both in raw crosh and in vim.

![Screenshot 2019-04-25 at 04 17 13](https://user-images.githubusercontent.com/29130152/56707510-1838ee80-6711-11e9-814f-afe02e8d0f3c.png)
![Screenshot 2019-04-25 at 04 09 25](https://user-images.githubusercontent.com/29130152/56707513-1c650c00-6711-11e9-89f8-39b3d325edac.png)
