### PR TITLE
Add "main" to package.json for easy NPM imports

### DIFF
--- a/distr/fira_code.css
+++ b/distr/fira_code.css
@@ -1,7 +1,7 @@
 @font-face {
   font-family: 'Fira Code';
   src: url('woff2/FiraCode-Light.woff2') format('woff2'),
-    url("woff2/FiraCode-Light.woff") format("woff");
+    url("woff/FiraCode-Light.woff") format("woff");
   font-weight: 300;
   font-style: normal;
 }
@@ -9,7 +9,7 @@
 @font-face {
   font-family: 'Fira Code';
   src: url('woff2/FiraCode-Regular.woff2') format('woff2'),
-    url("woff2/FiraCode-Regular.woff") format("woff");
+    url("woff/FiraCode-Regular.woff") format("woff");
   font-weight: 400;
   font-style: normal;
 }
@@ -17,7 +17,7 @@
 @font-face {
   font-family: 'Fira Code';
   src: url('woff2/FiraCode-Medium.woff2') format('woff2'),
-    url("woff2/FiraCode-Medium.woff") format("woff");
+    url("woff/FiraCode-Medium.woff") format("woff");
   font-weight: 500;
   font-style: normal;
 }
@@ -25,7 +25,7 @@
 @font-face {
   font-family: 'Fira Code';
   src: url('woff2/FiraCode-Bold.woff2') format('woff2'),
-    url("woff2/FiraCode-Bold.woff") format("woff");
+    url("woff/FiraCode-Bold.woff") format("woff");
   font-weight: 700;
   font-style: normal;
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "firacode",
   "version": "1.206.0",
   "description": "Fira Code: monospaced font with programming ligatures",
+  "main": "distr/fira_code.css",
   "keywords": [
     "font",
     "Mozilla Fira Type Family",


### PR DESCRIPTION
This adds “main” to the package.json which points to the CSS. This enables easy importing when used as an NPM package (for example, on a [Gatsby site](https://www.gatsbyjs.org/docs/importing-assets-into-files/)).

Before, to import the fonts you would have to use: 

```javascript
import "firacode/distr/fira_code.css";
```

Now, you can simply type: 

```javascript
import "firacode";
```

This also fixes a few lines of the CSS that (seemed to be?) pointing to incorrect file paths.