### PR TITLE
Add installation instructions for Visual Studio 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Swift:
 | **VimR** ([instructions](https://github.com/qvacua/vimr/wiki#ligatures)) |
 | **Visual Studio 2015** |
 | **Visual Studio 2017** ([instructions](https://github.com/tonsky/FiraCode/wiki/Visual-Studio-2017-Instructions)) |
+| **Visual Studio 2019** ([instructions](https://github.com/tonsky/FiraCode/wiki/Visual-Studio-2019-Instructions)) |
 | **Visual Studio Code** ([instructions](https://github.com/tonsky/FiraCode/wiki/VS-Code-Instructions)) |
 | **WebStorm** (2016.2+, [instructions](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions)) |
 | **Xamarin Studio/Monodevelop** |


### PR DESCRIPTION
Updated the Readme file to include the instructions for Visual Studio 2019.
Also added a wiki page with these instructions (based on the one for Visual Studio 2017).
https://github.com/tonsky/FiraCode/wiki/Visual-Studio-2019-Instructions
