### PR TITLE
Make `font-feature-settings` syntax a little shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ font-family: 'Fira Code', monospace;
 ```
 
 
-- IE 10+, Edge: enable with `font-feature-settings: "calt" 1;`
+- IE 10+, Edge: enable with `font-feature-settings: "calt";`
 - Firefox
 - Safari
 - Chromium-based browsers (Chrome, Opera)


### PR DESCRIPTION
According to the [spec](https://drafts.csswg.org/css-fonts-3/#propdef-font-feature-settings), they mean the same.
> If the value is omitted, a value of 1 is assumed. 

Tested on IE 10, IE 11 and Edge with no problem.