### PR TITLE
Fix macOS installation instructions

### DIFF
--- a/distr/README.txt
+++ b/distr/README.txt
@@ -26,8 +26,8 @@ OR
 
 Use http://brew.sh:
 
-    brew tap caskroom/fonts
-    brew cask install font-fira-code
+    `brew tap homebrew/cask-fonts`
+    `brew cask install font-fira-code`
 
 
 Ubuntu Zesty (17.04), Debian Stretch (9) or newer


### PR DESCRIPTION
Brew tap font cask instruction was wrong.

Replaces

```zsh
brew tap caskroom/fonts
brew cask install font-fira-code
```
with
```
brew tap homebrew/cask-fonts`
brew cask install font-fira-code`
```
