### PR TITLE
Change "Stylistic sets" into a heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Swift:
 
 <img src="./showcases/swift.png">
 
-Stylistic sets:
+### Stylistic sets
 
 See [How to enable](https://github.com/tonsky/FiraCode/wiki/How-to-enable-stylistic-sets)
 


### PR DESCRIPTION
This makes it possible to link to this section, in the browser, using #stylistic-sets