### PR TITLE
Add st to supported terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Swift:
 | **upterm**         |
 | **Windows Terminal** |
 | **ZOC** (macOS)    |
+| **st** ([patch](https://st.suckless.org/patches/ligatures/)) |
 
 ### Editor compatibility list
 


### PR DESCRIPTION
st now supports ligatures. This PR adds it to the list of supported terminals in README.md.