### PR TITLE
Suggest to install ttf version in Arch Linux

### DIFF
--- a/distr/README.txt
+++ b/distr/README.txt
@@ -40,7 +40,7 @@ Ubuntu Zesty (17.04), Debian Stretch (9) or newer
 Arch Linux
 ----------
 
-Fira Code package is available in the official repository: https://www.archlinux.org/packages/community/any/otf-fira-code/.
+Fira Code package is available in the official repository: https://www.archlinux.org/packages/community/any/ttf-fira-code/.
 
 Variant of Fira Code package is available in the AUR: https://aur.archlinux.org/packages/otf-fira-code-git/.
 


### PR DESCRIPTION
The otf-fira-code package is just removed from Arch Linux community repo. ttf-fira-code is distributed from the start. 
Related #939