### PR TITLE
split Terminal compatibility list by Platform in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,23 +122,48 @@ Unicode coverage makes Fira Code a great choice for mathematical writing.
 
 ### Terminal compatibility list
 
+#### Cross Platform (incl. Web)
+
 | Works              | Doesn’t work       |
 |--------------------|--------------------|
-| **Butterfly**      | **Alacritty**      |
-| **crosh** (ChromeOS, [instructions](https://github.com/tonsky/FiraCode/wiki/ChromeOS-Terminal)) | **Windows Console (conhost.exe)** |
-| **Hyper.app**      | **Cmder**          |
-| **iTerm 2** ([3.1+](https://gitlab.com/gnachman/iterm2/issues/3568#note_13118332)) | **ConEmu** |
-| **Kitty**          | **GNOME Terminal** |
+| **[Butterfly](https://github.com/paradoxxxzero/butterfly)**      | **[Alacritty](https://github.com/alacritty/alacritty)**      |
+| **[Hyper.app](https://hyper.is)**      |           |
+| **[Kitty](https://sw.kovidgoyal.net/kitty/)**          |  |
+
+#### Linux only
+
+| Works              | Doesn’t work       |
+|--------------------|--------------------|
 | **Konsole**        | **mate-terminal**  |
-| **mintty** (partial support [2.8.3+](https://github.com/mintty/mintty/issues/601))| **PuTTY** |
 | **QTerminal**      | **rxvt**           |
-| **Terminal.app**   | **xterm**          |
-| **Termux**         | **ZOC** (Windows)  |
-| **Token2Shell/MD** | **gtkterm, guake, LXTerminal, sakura, Terminator, xfce4-terminal,** and other libvte-based terminals ([bug report](https://bugzilla.gnome.org/show_bug.cgi?id=584160)) |
-| **upterm**         |
-| **Windows Terminal** |
-| **ZOC** (macOS)    |
-| **st** ([patch](https://st.suckless.org/patches/ligatures/)) |
+| **Termux**         | **GNOME Terminal** |
+| | **gtkterm, guake, LXTerminal, sakura, Terminator, xfce4-terminal,** and other libvte-based terminals ([bug report](https://bugzilla.gnome.org/show_bug.cgi?id=584160)) |
+| **st** ([patch](https://st.suckless.org/patches/ligatures/)) | **xterm** |
+
+#### Mac only
+
+| Works              | Doesn’t work       |
+|--------------------|--------------------|
+| **iTerm 2** ([3.1+](https://gitlab.com/gnachman/iterm2/issues/3568#note_13118332)) |  |
+| **Terminal.app**   | |
+| **ZOC** (macOS)    | |
+
+#### Windows only
+
+| Works              | Doesn’t work       |
+|--------------------|--------------------|
+| **Windows Terminal** | **Windows Console (conhost.exe)** |
+| **mintty** (partial support [2.8.3+](https://github.com/mintty/mintty/issues/601))| **PuTTY** |
+| **[Token2Shell/MD](https://token2shell.com)** | **Cmder** |
+| | **ConEmu** |
+| | **ZOC** (Windows) |
+
+#### ChromeOS only
+
+| Works              | Doesn’t work       |
+|--------------------|--------------------|
+| **crosh** (ChromeOS, [instructions](https://github.com/tonsky/FiraCode/wiki/ChromeOS-Terminal)) |  |
+
 
 ### Browser support
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Unicode coverage makes Fira Code a great choice for mathematical writing.
 | Works              | Doesn’t work       |
 |--------------------|--------------------|
 | **[Butterfly](https://github.com/paradoxxxzero/butterfly)**      | **[Alacritty](https://github.com/alacritty/alacritty)**      |
-| **[Hyper.app](https://hyper.is)**      |           |
+| | **[Hyper.app](https://hyper.is)** (see [issue #3607](https://github.com/vercel/hyper/issues/3607) |
 | **[Kitty](https://sw.kovidgoyal.net/kitty/)**          |  |
 
 #### Linux only


### PR DESCRIPTION
How about splitting the Terminal compatibility by Platform?

I've found it more readable and useful like this, as I was looking for a Terminal that works with FiraCode.

PS: https://github.com/railsware/upterm is removed, because deprecated (unmaintained)