### PR TITLE
Use git-tagged version when packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ dep:
 
 build:
 	docker run --rm -v ${PWD}:/opt fira:latest ./script/build
+
+package:
+	./script/package

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Fira Code: free monospaced font with programming ligatures
 
-<img src="./extras/logo.svg">
+![Fira Code](./extras/logo.svg)
 
 ### Problem
 
@@ -12,17 +12,17 @@ Fira Code is a free monospaced font containing ligatures for common programming 
 
 ### Download & Install
 
-<a href="https://github.com/tonsky/FiraCode/releases/download/5.2/Fira_Code_v5.2.zip"><img src="./extras/download.png" width="520" height="130"></a>
+<a href="https://github.com/tonsky/FiraCode/releases/download/5.2/Fira_Code_v5.2.zip"><img alt="Fira_Code_v5.2.zip - June 12, 2020 - 2.3 MB" src="./extras/download.png" width="520" height="130"></a>
 
 Then:
 
-- <a href="https://github.com/tonsky/FiraCode/wiki">How to Install</a>
-- <a href="https://github.com/tonsky/FiraCode/wiki#troubleshooting">Troubleshooting</a>
-- <a href="https://twitter.com/FiraCode">News & Updates</a>
+- [How to Install](https://github.com/tonsky/FiraCode/wiki)
+- [Troubleshooting](https://github.com/tonsky/FiraCode/wiki#troubleshooting)
+- [News & Updates](https://twitter.com/FiraCode)
 
 ### Support
 
-<a href="https://github.com/sponsors/tonsky" target="_blank"><img src="./extras/sponsor.png"></a>
+<a href="https://github.com/sponsors/tonsky" target="_blank"><img alt="Sponsor" src="./extras/sponsor.png"></a>
 
 Fira Code is a personal, free-time project with no funding and a huge [feature request backlog](https://github.com/tonsky/FiraCode/issues). If you love it, consider supporting its development via [GitHub Sponsors](https://github.com/sponsors/tonsky) or [Patreon](https://patreon.com/tonsky). Any help counts!
 

--- a/script/package
+++ b/script/package
@@ -1,22 +1,7 @@
 #!/bin/zsh -euo pipefail
 cd "`dirname $0`/.."
 
-setopt BASH_REMATCH
-MAJOR=`cat FiraCode.glyphs | grep versionMajor`
-VERSION=""
-
-if [[ $MAJOR =~ 'versionMajor = ([0-9]+);' ]] ; then
-    VERSION="${BASH_REMATCH[2]}"
-fi
-
-MINOR=`cat FiraCode.glyphs | grep versionMinor`
-if [[ $MINOR =~ 'versionMinor = ([0-9]+);' ]] ; then
-    MATCH="${BASH_REMATCH[2]}"
-    if [ "$MATCH" != "0" ] ; then
-        VERSION="$VERSION.$MATCH"
-    fi
-fi
-
+VERSION="$(git describe --tags)"
 FILE="Fira_Code_v$VERSION.zip"
 rm -f $FILE
 


### PR DESCRIPTION
I built Fira Code today to start using the new features before 6.0. This patch uses the git-tagged version when packaging dist into a zip. This has the advantage of producing unique version numbers between releases when the version in FiraCode.glyphs hasn't been bumped. For example, `git describe --tags` returns a version string like '5.2-36-g15f7925' when on commit g15f7925, which is 36 commits after the tag 5.2.

While I was at it, I added alt text to README images that were not described in context and converted bare links to Markdown `[]()`-style. As a note, `Mb` in extras/download.png stands for megabit, when it should be `MB` for megabyte.