### PR TITLE
Fix missing script .sh extensions; add Docker build notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ dep:
 	docker build -t fira:latest .
 
 build:
-	docker run --rm -v ${PWD}:/opt fira:latest ./script/build
+	docker run --rm -v ${PWD}:/opt fira:latest ./script/build.sh
 
 package:
-	./script/package
+	./script/package.sh

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Unicode coverage makes Fira Code a great choice for mathematical writing.
 | **CLion** (2016.2+, [instructions](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions)) | **Monkey Studio IDE** |
 | **Cloud9** ([instructions](https://github.com/tonsky/FiraCode/wiki/Cloud9-Instructions)) | **UltraEdit** |
 | **Coda 2** |
-| **CodeLite** | 
-| **CodeRunner** | 
+| **CodeLite** |
+| **CodeRunner** |
 | **CotEditor** |
 | **Eclipse** |
 | **elementary Code** |
@@ -99,7 +99,7 @@ Unicode coverage makes Fira Code a great choice for mathematical writing.
 | **Notepad** (Windows) |
 | **Notepad++** (with a [workaround](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/2287#issuecomment-256638098))  |
 | **Notepad3** ([instructions](https://github.com/rizonesoft/Notepad3/issues/361#issuecomment-365977420))|
-| **Nova** | 
+| **Nova** |
 | **PhpStorm** (2016.2+, [instructions](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions)) |
 | **PyCharm** (2016.2+, [instructions](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions)) |
 | **QOwnNotes** (21.16.6+) |
@@ -196,13 +196,23 @@ In case you want to alter FiraCode.glyphs and build OTF/TTF/WOFF files yourself,
 
 ```bash
 # install all required build tools
-./script/bootstrap
+./script/bootstrap_macos.sh
 
 # build the font files
-./script/build
+./script/build.sh
 
 # install OTFs to ~/Library/Fonts
-./script/install
+cp distr/otf/*.otf ~/Library/Fonts
+```
+
+Alternatively, you can build Fira Code using Docker:
+
+```bash
+# install dependencies in a container and build the font files
+make
+
+# package the font files from dist/ into a zip
+make package
 ```
 
 ### Credits

--- a/script/everything
+++ b/script/everything
@@ -2,8 +2,8 @@
 cd "`dirname $0`/.."
 
 ./script/check_widths
-# ./script/build_ttf
-./script/build_variable
-./script/build_woff
-./script/build_woff2
-./script/package
+# ./script/build_ttf.sh
+./script/build_variable.sh
+./script/build_woff.sh
+./script/build_woff2.sh
+./script/package.sh


### PR DESCRIPTION
- Fixes the script filenames to match the renames made in https://github.com/tonsky/FiraCode/commit/6bf3854628f8fd0450cb65a141350b991cdd3ed3.
- Adds a small section in README.md describing building using Docker.
- Replaces usage of deleted `script/install` with former contents.