### PR TITLE
Update editor compatibility information for gVim

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Unicode coverage makes Fira Code a great choice for mathematical writing:
 | **Anjuta** (unless at the EOF) | **Delphi IDE** |
 | **AppCode** (2016.2+, [instructions](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions)) | Standalone **Emacs** ([workaround](https://github.com/tonsky/FiraCode/wiki/Emacs-instructions)) |
 | **Atom** 1.1 or newer ([instructions](https://github.com/tonsky/FiraCode/wiki/Atom-instructions)) | **Godot** ([issue](https://github.com/godotengine/godot/issues/9961)) |
-| **BBEdit/TextWrangler** (v. 11 only, [instructions](https://github.com/tonsky/FiraCode/wiki/BBEdit-instructions)) | **gVim** (Windows [workaround](https://github.com/tonsky/FiraCode/issues/462)) |
+| **BBEdit/TextWrangler** (v. 11 only, [instructions](https://github.com/tonsky/FiraCode/wiki/BBEdit-instructions)) |
 | **Brackets** (with [this plugin](https://github.com/polo2ro/firacode-in-brackets)) | **IDLE** |
 | **Chocolat** | **KDevelop 4** |
 | **CLion** (2016.2+, [instructions](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions)) | **Monkey Studio IDE** |
@@ -95,6 +95,7 @@ Unicode coverage makes Fira Code a great choice for mathematical writing:
 | **gEdit / Pluma** |
 | **GNOME Builder** |
 | **GoormIDE** ([instructions](https://github.com/tonsky/FiraCode/wiki/GoormIDE-Instructions)) |
+| **gVim** (GTK GUI (8.2.3524+), [instructions](https://vimhelp.org/options.txt.html#%27guiligatures%27); Windows (with DirectX renderer), [instructions](https://github.com/tonsky/FiraCode/issues/462)) |
 | **IntelliJ IDEA** (2016.2+, [instructions](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions)) |
 | **Kate, KWrite** |
 | **KDevelop 5+** |


### PR DESCRIPTION
Ligatures were already supported on Windows when using DirectX renderer ([instructions](https://github.com/tonsky/FiraCode/issues/462)).
In addition to that ligature support has recently been added for GTK GUI (https://github.com/vim/vim/commit/4eeedc09fed0cbbb3ba48317e0a01e20cd0b4f80, [instructions](https://vimhelp.org/options.txt.html#%27guiligatures%27)).