### PR TITLE
Raku IDE Comma supports FiraCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Unicode coverage makes Fira Code a great choice for mathematical writing:
 | **Coda 2** |
 | **CodeLite** |
 | **CodeRunner** |
+| **Comma** (Under: Preferences > Editor > Font) |
 | **CotEditor** |
 | **Eclipse** |
 | **elementary Code** |


### PR DESCRIPTION
Select installed FiraCode under Preferences... > Editor > Font
and toggle the checkbox Enable ligatures in the same place.