### PR TITLE
Optimise formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,9 @@ Fira Code is not only about ligatures. Some fine-tuning is done for punctuation 
 
 <img src="./extras/typographics.png" width="754">
 
-Fira Code comes with a few different character variants, so that everyone can choose what’s best for them. [How to enable](https://github.com/tonsky/FiraCode/wiki/How-to-enable-stylistic-sets)
+Fira Code comes with a few different character variants, so that everyone can [choose](https://github.com/tonsky/FiraCode/wiki/How-to-enable-stylistic-sets) what’s best for them.
 
 <img src="./extras/character_variants.png" width="754">
-
-Some ligatures can be altered or enabled using stylistic sets/character variants:
 
 <img src="./extras/ligature_variants.png" width="754">
 


### PR DESCRIPTION
This commit gets rid of a violation of the DRY principle. In the previous version of the section, it was possible to miss the link to the relevant documentation and the information, that there are variants was repeated twice. Now, in the new version, this is solved and the information is displayed just once.

New version:

![Screenshot_20220717_115229](https://user-images.githubusercontent.com/6344099/179393137-4d724676-8313-476f-b2e4-7dbeb822e7a3.png)

Old version: 

![Screenshot_20220717_115336](https://user-images.githubusercontent.com/6344099/179393152-f7a40e2d-8467-4654-b8f5-71769508acc1.png)



