### PR TITLE
Docs: BBEdit support

### DIFF
--- a/LEEME.md
+++ b/LEEME.md
@@ -82,7 +82,7 @@ La covertura del estándar Unicode hace de Fira Code una gran elección para la 
 | **Anjuta** (excepto con EOF) | **Delphi IDE** |
 | **AppCode** (2016.2+, [instrucciones](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions)) | **Emacs** por sí solo ([solución alternativa](https://github.com/tonsky/FiraCode/wiki/Emacs-instructions)) |
 | **Atom** 1.1 o más nuevo ([instrucciones](https://github.com/tonsky/FiraCode/wiki/Atom-instructions)) | **Godot** ([reporte](https://github.com/godotengine/godot/issues/9961)) |
-| **BBEdit/TextWrangler** (solamente v. 11, [instrucciones](https://github.com/tonsky/FiraCode/wiki/BBEdit-instructions)) | **IDLE** |
+| **BBEdit** (14.6+, [instrucciones](https://github.com/tonsky/FiraCode/wiki/BBEdit-instructions)) | **IDLE** |
 | **Brackets** (con [este plugin](https://github.com/polo2ro/firacode-in-brackets)) | **KDevelop 4** |
 | **Chocolat** | **Monkey Studio IDE** |
 | **CLion** (2016.2+, [instrucciones](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions)) | **UltraEdit** |

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Unicode coverage makes Fira Code a great choice for mathematical writing:
 | **Anjuta** (unless at the EOF) | **Delphi IDE** |
 | **AppCode** (2016.2+, [instructions](https://github.com/tonsky/FiraCode/wiki/IntelliJ-products-instructions)) | Standalone **Emacs** ([workaround](https://github.com/tonsky/FiraCode/wiki/Emacs-instructions)) | **IDLE** |
 | **Atom** 1.1 or newer ([instructions](https://github.com/tonsky/FiraCode/wiki/Atom-instructions)) | **KDevelop 4** |
-| **BBEdit/TextWrangler** (v. 11 only, [instructions](https://github.com/tonsky/FiraCode/wiki/BBEdit-instructions)) | **Monkey Studio IDE** |
+| **BBEdit** (14.6+ [instructions](https://github.com/tonsky/FiraCode/wiki/BBEdit-instructions)) | **Monkey Studio IDE** |
 | **Brackets** (with [this plugin](https://github.com/polo2ro/firacode-in-brackets)) | 
 | **Chocolat** | **UltraEdit** |
 | **CLion** (2016.2+, [instructions](https://github.com/tonsky/FiraCode/wiki/IntelliJ-products-instructions)) | 

--- a/README_CN.md
+++ b/README_CN.md
@@ -96,7 +96,7 @@ Unicode 覆盖使 Fira Code 成为数学写作的绝佳选择：
 | **Anjuta** (除非在 EOF) | **Delphi IDE** |
 | **AppCode** (2016.2+, [说明](https://github.com/tonsky/FiraCode/wiki/IntelliJ-products-instructions)) | Standalone **Emacs** ([解决方法](https://github.com/tonsky/FiraCode/wiki/Emacs-instructions)) | **IDLE** |
 | **Atom** 1.1 或更新版本 ([说明](https://github.com/tonsky/FiraCode/wiki/Atom-instructions)) | **KDevelop 4** |
-| **BBEdit/TextWrangler** (仅限 v. 11, [说明](https://github.com/tonsky/FiraCode/wiki/BBEdit-instructions)) | **Monkey Studio IDE** |
+| **BBEdit** (14.6+, [说明](https://github.com/tonsky/FiraCode/wiki/BBEdit-instructions)) | **Monkey Studio IDE** |
 | **Brackets** (使用 [此插件](https://github.com/polo2ro/firacode-in-brackets)) | 
 | **Chocolat** | **UltraEdit** |
 | **CLion** (2016.2+, [说明](https://github.com/tonsky/FiraCode/wiki/IntelliJ-products-instructions)) | 

--- a/distr/README.txt
+++ b/distr/README.txt
@@ -155,14 +155,11 @@ Additionally, if a Color Scheme is selected:
 4. Select Fira Code as "Primary font" under Settings → Editor → Color Scheme → Color Scheme Font
 
 
-BBEdit, TextWrangler
---------------------
+BBEdit
+------
 
-Run in your terminal:
-
-    defaults write com.barebones.bbedit "EnableFontLigatures_Fira Code" -bool YES
-
-Source: https://www.barebones.com/support/bbedit/ExpertPreferences.html
+1. Install FiraCode as per the [macOS installation instructions](https://github.com/tonsky/FiraCode/wiki/Installing#macos)
+2. Open BBEdit preferences, Editor Defaults, assign Fira Code as the Default font
 
 
 Brackets


### PR DESCRIPTION
[Latest version of BBEdit](https://www.barebones.com/support/bbedit/notes-14.6.html) supports ligatures once more.

BBEdit no longer requires expert preferences to enable ligatures

TextWrangler is no more – replaced by the unlicenced version of BBEdit.

Update the README files to reflect these changes.