### PR TITLE
Add local sources first

### DIFF
--- a/distr/fira_code.css
+++ b/distr/fira_code.css
@@ -1,6 +1,7 @@
 @font-face {
   font-family: 'Fira Code';
-  src: url('woff2/FiraCode-Light.woff2') format('woff2'),
+  src: local('Fira Code Light'),
+    url('woff2/FiraCode-Light.woff2') format('woff2'),
     url('woff/FiraCode-Light.woff') format('woff');
   font-weight: 300;
   font-style: normal;
@@ -8,7 +9,9 @@
 
 @font-face {
   font-family: 'Fira Code';
-  src: url('woff2/FiraCode-Regular.woff2') format('woff2'),
+  src: local('Fira Code'),
+    local('Fira Code Regular'),
+    url('woff2/FiraCode-Regular.woff2') format('woff2'),
     url('woff/FiraCode-Regular.woff') format('woff');
   font-weight: 400;
   font-style: normal;
@@ -16,7 +19,8 @@
 
 @font-face {
   font-family: 'Fira Code';
-  src: url('woff2/FiraCode-Medium.woff2') format('woff2'),
+  src: local('Fira Code Medium'),
+    url('woff2/FiraCode-Medium.woff2') format('woff2'),
     url('woff/FiraCode-Medium.woff') format('woff');
   font-weight: 500;
   font-style: normal;
@@ -24,7 +28,8 @@
 
 @font-face {
   font-family: 'Fira Code';
-  src: url('woff2/FiraCode-SemiBold.woff2') format('woff2'),
+  src: local('Fira Code SemiBold'),
+    url('woff2/FiraCode-SemiBold.woff2') format('woff2'),
     url('woff/FiraCode-SemiBold.woff') format('woff');
   font-weight: 600;
   font-style: normal;
@@ -32,7 +37,8 @@
 
 @font-face {
   font-family: 'Fira Code';
-  src: url('woff2/FiraCode-Bold.woff2') format('woff2'),
+  src: local('Fira Code Bold'),
+    url('woff2/FiraCode-Bold.woff2') format('woff2'),
     url('woff/FiraCode-Bold.woff') format('woff');
   font-weight: 700;
   font-style: normal;
@@ -40,7 +46,9 @@
 
 @font-face {
   font-family: 'Fira Code VF';
-  src: url('woff2/FiraCode-VF.woff2') format('woff2-variations'),
+  src: local('Fira Code'),
+    local('Fira Code VF'),
+    url('woff2/FiraCode-VF.woff2') format('woff2-variations'),
     url('woff/FiraCode-VF.woff') format('woff-variations');
   /* font-weight requires a range: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/Variable_Fonts_Guide#Using_a_variable_font_font-face_changes */
   font-weight: 300 700;


### PR DESCRIPTION
I use an Electron-based app that runs on both my PC and my Android tablet. I can @import a stylesheet from the CDN, but then it will always use the CDN's version of the font, even though I have the font installed on my PC.

By adding the `local()` calls that tries to find the font on the OS first, I can point to a single CDN url for both my PC and my tablet, and my PC will prefer the locally installed fonts, while my tablet will load the fonts remotely.

This may be unexpected behavior, so I'll leave that up to the community, but it is a small optimization for my use case.