### PR TITLE
fix: minor improvements in set-vertical-metrics.py & release.py

### DIFF
--- a/googlefonts-qa/scripts/set-vertical-metrics.py
+++ b/googlefonts-qa/scripts/set-vertical-metrics.py
@@ -19,7 +19,7 @@ font = Glyphs.font
 
 
 
-caps = ["A", "Aacute", "Abreve", "Acircumflex", "Adieresis", "Agrave", "Amacron", "Aogonek", "Aring", "Aringacute", "Atilde", "AE", "AEacute", "B", "C", "Cacute", "Ccaron", "Ccedilla", "Ccircumflex", "Cdotaccent", "D", "Eth", "Dcaron", "Dcroat", "Ddotbelow", "E", "Eacute", "Ebreve", "Ecaron", "Ecircumflex", "Edieresis", "Edotaccent", "Edotbelow", "Egrave", "Emacron", "Eogonek", "Etilde", "F", "G", "Gbreve", "Gcircumflex", "Gcommaaccent", "Gdotaccent", "H", "Hbar", "Hcircumflex", "Hdotbelow", "I", "IJ", "Iacute", "Ibreve", "Icircumflex", "Idieresis", "Idotaccent", "Idotbelow", "Igrave", "Imacron", "Iogonek", "Itilde", "J", "Jcircumflex", "K", "Kcommaaccent", "L", "Lacute", "Lcaron", "Lcommaaccent", "Ldot", "Lslash", "M", "N", "Nacute", "Ncaron", "Ncommaaccent", "Ndotaccent", "Eng", "Ntilde", "O", "Oacute", "Obreve", "Ocircumflex", "Odieresis", "Odotbelow", "Ograve", "Ohungarumlaut", "Omacron", "Oogonek", "Oslash", "Oslashacute", "Otilde", "OE", "P", "Thorn", "Q", "R", "Racute", "Rcaron", "Rcommaaccent", "Rdotbelow", "S", "Sacute", "Scaron", "Scircumflex", "Sdotbelow", "Schwa", "T", "Tbar", "Tcaron", "Tdotbelow", "U", "Uacute", "Ubreve", "Ucircumflex", "Udieresis", "Udotbelow", "Ugrave", "Uhungarumlaut", "Umacron", "Uogonek", "Uring", "Utilde", "V", "W", "Wacute", "Wcircumflex", "Wdieresis", "Wgrave", "X", "Y", "Yacute", "Ycircumflex", "Ydieresis", "Ygrave", "Ytilde", "Z", "Zacute", "Zcaron", "Zdotaccent", "Zdotbelow", "uni015E", "uni0162", "uni01C4", "uni01C5", "uni01C7", "uni01C8", "uni01CA", "uni01CB", "uni01F1", "uni01F2", "uni0218", "uni021A" ]  
+caps = ["A", "Aacute", "Abreve", "Acircumflex", "Adieresis", "Agrave", "Amacron", "Aogonek", "Aring", "Aringacute", "Atilde", "AE", "AEacute", "B", "C", "Cacute", "Ccaron", "Ccedilla", "Ccircumflex", "Cdotaccent", "D", "Eth", "Dcaron", "Dcroat", "Ddotbelow", "E", "Eacute", "Ebreve", "Ecaron", "Ecircumflex", "Edieresis", "Edotaccent", "Edotbelow", "Egrave", "Emacron", "Eogonek", "Etilde", "F", "G", "Gbreve", "Gcircumflex", "Gcommaaccent", "Gdotaccent", "H", "Hbar", "Hcircumflex", "Hdotbelow", "I", "IJ", "Iacute", "Ibreve", "Icircumflex", "Idieresis", "Idotaccent", "Idotbelow", "Igrave", "Imacron", "Iogonek", "Itilde", "J", "Jcircumflex", "K", "Kcommaaccent", "L", "Lacute", "Lcaron", "Lcommaaccent", "Ldot", "Lslash", "M", "N", "Nacute", "Ncaron", "Ncommaaccent", "Ndotaccent", "Eng", "Ntilde", "O", "Oacute", "Obreve", "Ocircumflex", "Odieresis", "Odotbelow", "Ograve", "Ohungarumlaut", "Omacron", "Oogonek", "Oslash", "Oslashacute", "Otilde", "OE", "P", "Thorn", "Q", "R", "Racute", "Rcaron", "Rcommaaccent", "Rdotbelow", "S", "Sacute", "Scaron", "Scircumflex", "Sdotbelow", "Schwa", "T", "Tbar", "Tcaron", "Tdotbelow", "U", "Uacute", "Ubreve", "Ucircumflex", "Udieresis", "Udotbelow", "Ugrave", "Uhungarumlaut", "Umacron", "Uogonek", "Uring", "Utilde", "V", "W", "Wacute", "Wcircumflex", "Wdieresis", "Wgrave", "X", "Y", "Yacute", "Ycircumflex", "Ydieresis", "Ygrave", "Ytilde", "Z", "Zacute", "Zcaron", "Zdotaccent", "Zdotbelow", "uni015E", "uni0162", "uni01C4", "uni01C5", "uni01C7", "uni01C8", "uni01CA", "uni01CB", "uni01F1", "uni01F2", "uni0218", "uni021A" ]
 lowercase = ["a", "aacute", "abreve", "acircumflex", "adieresis", "agrave", "amacron", "aogonek", "aring", "aringacute", "atilde", "ae", "aeacute", "b", "c", "cacute", "ccaron", "ccedilla", "ccircumflex", "cdotaccent", "d", "eth", "dcaron", "dcroat", "ddotbelow", "e", "eacute", "ebreve", "ecaron", "ecircumflex", "edieresis", "edotaccent", "edotbelow", "egrave", "emacron", "eogonek", "etilde", "schwa", "f", "g", "gbreve", "gcircumflex", "gcommaaccent", "gdotaccent", "h", "hbar", "hcircumflex", "hdotbelow", "i", "dotlessi", "iacute", "ibreve", "icircumflex", "idieresis", "idotbelow", "igrave", "ij", "imacron", "iogonek", "itilde", "j", "dotlessj", "jcircumflex", "k", "kcommaaccent", "kgreenlandic", "l", "lacute", "lcaron", "lcommaaccent", "ldot", "lslash", "m", "n", "nacute", "napostrophe", "ncaron", "ncommaaccent", "ndotaccent", "eng", "ntilde", "o", "oacute", "obreve", "ocircumflex", "odieresis", "odotbelow", "ograve", "ohungarumlaut", "omacron", "oogonek", "oslash", "oslashacute", "otilde", "oe", "p", "thorn", "q", "r", "racute", "rcaron", "rcommaaccent", "rdotbelow", "s", "sacute", "scaron", "scircumflex", "sdotbelow", "germandbls", "t", "tbar", "tcaron", "tdotbelow", "u", "uacute", "ubreve", "ucircumflex", "udieresis", "udotbelow", "ugrave", "uhungarumlaut", "umacron", "uni015F", "uni0163", "uni01C6", "uni01C9", "uni01CC", "uni01F3", "uni0219", "uni021B", "uogonek", "uring", "utilde", "v", "w", "wacute", "wcircumflex", "wdieresis", "wgrave", "x", "y", "yacute", "ycircumflex", "ydieresis", "ygrave", "ytilde", "z", "zacute", "zcaron", "zdotaccent", "zdotbelow", "c_t", "f_b", "f_f", "f_f_b", "f_f_h", "f_f_i", "f_f_j", "f_f_k", "f_f_l", "f_f_t", "f_h", "f_i", "f_j", "f_k", "f_l", "f_t", "s_t", ]
 
 # starter values
@@ -35,10 +35,10 @@ for glyph in font.glyphs:
 
   # get total yMax and yMin, for win values
   for layer in glyph.layers:
-  
+
     # get descender of current layer
     descent = layer.bounds.origin.y
-    
+
     # get ascender of current layer
     ascent = layer.bounds.size.height + descent  
 
@@ -46,34 +46,32 @@ for glyph in font.glyphs:
     if descent <= maxDescent:
       maxDescent = descent
       maxDescentGlyph = glyph.name
-      
+
     if ascent >= maxAscent:
       maxAscent = ascent
       maxAscentGlyph = glyph.name
 
   # get descender of current layer
   descent = layer.bounds.origin.y
-      
+
   # get ascender of current layer (total height of layer, subtracting value of descender)
   ascent = layer.bounds.size.height + descent
 
   # get maximums of only letters in list vars, for typo and hhea values
   if glyph.name in caps:
 
-    for layer in glyph.layers:
+    for _ in glyph.layers:
       if ascent >= mainMaxAscent:
         mainMaxAscent = ascent
         mainMaxAscentGlyph = glyph.name
 
 
-  if glyph.name in lowercase:
-      # if descent/ascent of current layer is greater than previous max descents/ascents, update the max descent/ascent
-      if descent <= mainMaxDescent:
-        mainMaxDescent = descent
-        mainMaxDescentGlyph = glyph.name
+  if glyph.name in lowercase and descent <= mainMaxDescent:
+    mainMaxDescent = descent
+    mainMaxDescentGlyph = glyph.name
 
 
-      
+
 
 # check values for sanity
 print(maxDescentGlyph, maxDescent, maxAscentGlyph, maxAscent)
@@ -93,13 +91,13 @@ totalSize = maxAscent + abs(maxDescent)
 
 font.customParameters["Use Typo Metrics"] = True
 
+typoLineGap = 0
 for master in font.masters:
 
   # Win Ascent/Descent = Font bbox yMax/yMin
   master.customParameters["winAscent"] = maxAscent
   master.customParameters["winDescent"] = abs(maxDescent)
 
-  typoLineGap = 0
   master.customParameters["typoLineGap"] = typoLineGap
   master.customParameters["hheaLineGap"] = typoLineGap
 

--- a/script/release.py
+++ b/script/release.py
@@ -38,13 +38,16 @@ def github_release(version):
   data = '{"tag_name":"' + version + '","name":"' + version + '"}'
   headers = github_headers()
   resp = urllib.request.urlopen(urllib.request.Request('https://api.github.com/repos/tonsky/FiraCode/releases', data=data.encode('utf-8'), headers=headers)).read()
-  upload_url = re.match('https://.*/assets', json.loads(resp.decode('utf-8'))['upload_url']).group(0)
+  upload_url = re.match('https://.*/assets',
+                        json.loads(resp.decode('utf-8'))['upload_url'])[0]
 
   print('github_release: Uploading', zip, 'to', upload_url)
   headers['Content-Type'] = 'application/zip'
   headers['Content-Length'] = os.path.getsize(zip)
   with open(zip, 'rb') as data:
-    urllib.request.urlopen(urllib.request.Request(upload_url + '?name=' + zip, data=data, headers=headers))
+    urllib.request.urlopen(
+        urllib.request.Request(
+            f'{upload_url}?name={zip}', data=data, headers=headers))
 
 @log_errors("npm_publish")
 def npm_publish(version):


### PR DESCRIPTION
- Replace unused for index with underscore [set-vertical-metrics.py#L63](https://github.com/joe733/FiraLang/blob/5433cc3712a81371c4dcc5f91ccf4be4446972c8/googlefonts-qa/scripts/set-vertical-metrics.py#L63)
- Merge nested if conditions [set-vertical-metrics.py#L69-L71](https://github.com/joe733/FiraLang/blob/5433cc3712a81371c4dcc5f91ccf4be4446972c8/googlefonts-qa/scripts/set-vertical-metrics.py#L69-L71)
- Hoist statements out of forloops [set-vertical-metrics.py#L94](https://github.com/joe733/FiraLang/blob/5433cc3712a81371c4dcc5f91ccf4be4446972c8/googlefonts-qa/scripts/set-vertical-metrics.py#L94)
- Replace m.group(x) with m[x] for re.Match objects [release.py#L41-L42](https://github.com/joe733/FiraLang/blob/5433cc3712a81371c4dcc5f91ccf4be4446972c8/script/release.py#L41-L42)
- Use f-string instead of string concatenation [release.py#L48-L50](https://github.com/joe733/FiraLang/blob/5433cc3712a81371c4dcc5f91ccf4be4446972c8/script/release.py#L48-L50)
- Removed extra white-spaces

> Not me! An AI doing it's thing :slightly_smiling_face: