### PR TITLE
Update README with cv01, ss01 , zero, onum, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Fira Code is not only about ligatures. Some fine-tuning is done for punctuation 
 
 <img src="./extras/typographics.png" width="754">
 
-Fira Code comes with a few different character variants, so that everyone can choose what’s best for them. [How to enable](https://github.com/tonsky/FiraCode/wiki/How-to-enable-stylistic-sets)
+Fira Code comes with a few different character variants (`cv01`, `cv02`, etc), stylistic sets (`ss01`, `ss02` , etc) and other font features (`zero`, `onum`, `calt`, etc), so that everyone can choose what’s best for them. [How to enable](https://github.com/tonsky/FiraCode/wiki/How-to-enable-stylistic-sets)
 
 <img src="./extras/character_variants.png" width="754">
 


### PR DESCRIPTION
Those are already reference in the images, but they are not searchable.  By putting in the text is easier to find as you can search for calt, onum, zero, cv01, ss01,  and find the relevant documentation