### PR TITLE
Add Block elements from the Symbols for Legacy Computing

### DIFF
--- a/FiraCode.glyphs
+++ b/FiraCode.glyphs
@@ -1,7 +1,7 @@
 {
 .appVersion = "3108";
 DisplayStrings = (
-"/lowerOneEighthBlock"
+"/horizontalOneEighthBlock-1358"
 );
 classes = (
 {
@@ -120183,6 +120183,64 @@ unicode = 2570;
 },
 {
 color = 3;
+glyphname = upperAndlowerOneEighthBlock;
+lastChange = "2023-12-31 14:06:05 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 -300 LINE",
+"0 -600 LINE",
+"1200 -600 LINE",
+"1200 -300 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 1500 LINE",
+"1200 1500 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 -300 LINE",
+"0 -600 LINE",
+"1200 -600 LINE",
+"1200 -300 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 1500 LINE",
+"1200 1500 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB80;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
 glyphname = upperOneQuarterBlock;
 lastChange = "2023-12-31 13:46:42 +0000";
 layers = (
@@ -129514,6 +129572,97 @@ nodes = (
 "333 1370 OFFCURVE",
 "464 1314 OFFCURVE",
 "597 1314 CURVE SMOOTH"
+);
+}
+);
+width = 1200;
+}
+);
+},
+{
+color = 3;
+glyphname = "horizontalOneEighthBlock-1358";
+lastChange = "2023-12-31 14:07:49 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 1500 LINE",
+"1200 1500 LINE",
+"1200 1800 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 1200 LINE",
+"0 900 LINE",
+"1200 900 LINE",
+"1200 1200 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 600 LINE",
+"0 300 LINE",
+"1200 300 LINE",
+"1200 600 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 -300 LINE",
+"0 -600 LINE",
+"1200 -600 LINE",
+"1200 -300 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 1500 LINE",
+"1200 1500 LINE",
+"1200 1800 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 1200 LINE",
+"0 900 LINE",
+"1200 900 LINE",
+"1200 1200 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 600 LINE",
+"0 300 LINE",
+"1200 300 LINE",
+"1200 600 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 -300 LINE",
+"0 -600 LINE",
+"1200 -600 LINE",
+"1200 -300 LINE"
 );
 }
 );

--- a/FiraCode.glyphs
+++ b/FiraCode.glyphs
@@ -509,6 +509,7 @@ id = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
 verticalStems = (
 124
 );
+visible = 1;
 weight = Light;
 weightValue = 62;
 xHeight = 1050;
@@ -119543,6 +119544,246 @@ unicode = 251D;
 },
 {
 color = 3;
+glyphname = "horizontalOneEighthBlock-2";
+lastChange = "2023-12-31 13:49:45 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1500 LINE",
+"0 1200 LINE",
+"1200 1200 LINE",
+"1200 1500 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1500 LINE",
+"0 1200 LINE",
+"1200 1200 LINE",
+"1200 1500 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB76;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = "horizontalOneEighthBlock-3";
+lastChange = "2023-12-31 13:55:00 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1200 LINE",
+"0 900 LINE",
+"1200 900 LINE",
+"1200 1200 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1200 LINE",
+"0 900 LINE",
+"1200 900 LINE",
+"1200 1200 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB77;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = "horizontalOneEighthBlock-4";
+lastChange = "2023-12-31 13:57:59 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 900 LINE",
+"0 600 LINE",
+"1200 600 LINE",
+"1200 900 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 900 LINE",
+"0 600 LINE",
+"1200 600 LINE",
+"1200 900 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB78;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = "horizontalOneEighthBlock-5";
+lastChange = "2023-12-31 13:58:03 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 600 LINE",
+"0 300 LINE",
+"1200 300 LINE",
+"1200 600 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 600 LINE",
+"0 300 LINE",
+"1200 300 LINE",
+"1200 600 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB79;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = "horizontalOneEighthBlock-6";
+lastChange = "2023-12-31 13:58:09 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 300 LINE",
+"0 0 LINE",
+"1200 0 LINE",
+"1200 300 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 300 LINE",
+"0 0 LINE",
+"1200 0 LINE",
+"1200 300 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB7A;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = "horizontalOneEighthBlock-7";
+lastChange = "2023-12-31 13:58:15 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 0 LINE",
+"0 -300 LINE",
+"1200 -300 LINE",
+"1200 0 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 0 LINE",
+"0 -300 LINE",
+"1200 -300 LINE",
+"1200 0 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB7B;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
 glyphname = uni256D;
 lastChange = "2020-04-05 21:57:02 +0000";
 layers = (
@@ -119764,7 +120005,7 @@ unicode = 2570;
 {
 color = 3;
 glyphname = upperOneQuarterBlock;
-lastChange = "2023-12-31 11:47:14 +0000";
+lastChange = "2023-12-31 13:46:42 +0000";
 layers = (
 {
 layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
@@ -119773,8 +120014,8 @@ paths = (
 closed = 1;
 nodes = (
 "0 1800 LINE",
-"0 1500 LINE",
-"1200 1500 LINE",
+"0 1200 LINE",
+"1200 1200 LINE",
 "1200 1800 LINE"
 );
 }

--- a/FiraCode.glyphs
+++ b/FiraCode.glyphs
@@ -1,8 +1,5 @@
 {
 .appVersion = "3108";
-DisplayStrings = (
-"/horizontalOneEighthBlock-1358"
-);
 classes = (
 {
 code = "A A-cy AE AEacute Aacute Abreve Abreve-cy Acircumflex Adieresis Adieresis-cy Agrave Aie-cy Aleutka-cy Alpha Alphadasia Alphadasiaoxia Alphadasiaoxiaprosgegrammeni Alphadasiaperispomeni Alphadasiaperispomeniprosgegrammeni Alphadasiaprosgegrammeni Alphadasiavaria Alphadasiavariaprosgegrammeni Alphamacron Alphaoxia Alphaprosgegrammeni Alphapsili Alphapsilioxia Alphapsilioxiaprosgegrammeni Alphapsiliperispomeni Alphapsiliperispomeniprosgegrammeni Alphapsiliprosgegrammeni Alphapsilivaria Alphapsilivariaprosgegrammeni Alphatonos Alphavaria Alphavrachy Amacron Aogonek Archaicsampi Aring Atilde B BdoubleStruck Be-cy Beta C CR Cacute Cacute.loclPLK Ccaron Ccedilla Ccircumflex Cdotaccent CdoubleStruck Che-cy Cheabkhasian-cy Chedescender-cy Chedescenderabkhasian-cy Chedieresis-cy Chekhakassian-cy Cheverticalstroke-cy Chi D Dcaron Dche-cy Dcroat De-cy Delta Digamma Dje-cy Dze-cy Dzeabkhasian-cy Dzhe-cy Dzzhe-cy E E-cy Eacute Ebreve Ecaron Ecircumflex Edieresis Edieresis-cy Edotaccent Ef-cy Egrave Eiotified-cy El-cy Eldescender-cy Elhook-cy Elmiddlehook-cy Eltail-cy Em-cy Emacron Emtail-cy En-cy EnLeftHook-cy Endescender-cy Eng Enghe-cy Enhook-cy Enmiddlehook-cy Entail-cy Eogonek Epsilon Epsilondasia Epsilondasiaoxia Epsilondasiavaria Epsilonoxia Epsilonpsili Epsilonpsilioxia Epsilonpsilivaria Epsilontonos Epsilonvaria Er-cy Ereversed-cy Ertick-cy Es-cy Esdescender-cy Eta Etadasia Etadasiaoxia Etadasiaoxiaprosgegrammeni Etadasiaperispomeni Etadasiaperispomeniprosgegrammeni Etadasiaprosgegrammeni Etadasiavaria Etadasiavariaprosgegrammeni Etaoxia Etaprosgegrammeni Etapsili Etapsilioxia Etapsilioxiaprosgegrammeni Etapsiliperispomeni Etapsiliperispomeniprosgegrammeni Etapsiliprosgegrammeni Etapsilivaria Etapsilivariaprosgegrammeni Etatonos Etavaria Eth F F.spacer F_l.liga.ss10 Fita-cy G Gamma Gbreve Gcircumflex Gcommaaccent Gdotaccent Ge-cy Gedescender-cy Germandbls Gestrokehook-cy Ghemiddlehook-cy Ghestroke-cy Gheupturn-cy Gje-cy H H18543 H18551 H22073 Ha-cy Haabkhasian-cy Hadescender-cy Hahook-cy Hardsign-cy Hastroke-cy Hbar Hcircumflex HdoubleStruck Heta I I-cy IJ Ia-cy Iacute Ibreve Icircumflex Idieresis Idieresis-cy Idotaccent Ie-cy Iebreve-cy Iegrave-cy Igrave Ii-cy Iigrave-cy Iishort-cy Iishorttail-cy Imacron Imacron-cy Io-cy Iogonek Iota Iotadasia Iotadasiaoxia Iotadasiaperispomeni Iotadasiavaria Iotadieresis Iotamacron Iotaoxia Iotapsili Iotapsilioxia Iotapsiliperispomeni Iotapsilivaria Iotatonos Iotavaria Iotavrachy Itilde Iu-cy Izhitsa-cy Izhitsadblgrave-cy J Jcircumflex Je-cy K Ka-cy Kabashkir-cy Kadescender-cy Kahook-cy KaiSymbol Kappa Kastroke-cy Kaverticalstroke-cy Kcommaaccent Kje-cy Komide-cy Komidje-cy Komidzje-cy Komilje-cy Kominje-cy Komisje-cy Komitje-cy Komizje-cy Koppa KoppaArchaic Ksi-cy L LIG Lacute Lambda Lcaron Lcommaaccent Ldot Lha-cy Lje-cy Lslash M Mu N Nacute Nacute.loclPLK Ncaron Ncommaaccent NdoubleStruck Nje-cy Ntilde Nu O O-cy OE Oacute Oacute.loclPLK Obarred-cy Obarreddieresis-cy Obreve Ocircumflex Odieresis Odieresis-cy Ograve Ohungarumlaut Omacron Omega Omega-cy Omegadasia Omegadasiaoxia Omegadasiaoxiaprosgegrammeni Omegadasiaperispomeni Omegadasiaperispomeniprosgegrammeni Omegadasiaprosgegrammeni Omegadasiavaria Omegadasiavariaprosgegrammeni Omegaoxia Omegaprosgegrammeni Omegapsili Omegapsilioxia Omegapsilioxiaprosgegrammeni Omegapsiliperispomeni Omegapsiliperispomeniprosgegrammeni Omegapsiliprosgegrammeni Omegapsilivaria Omegapsilivariaprosgegrammeni Omegatonos Omegavaria Omicron Omicrondasia Omicrondasiaoxia Omicrondasiavaria Omicronoxia Omicronpsili Omicronpsilioxia Omicronpsilivaria Omicrontonos Omicronvaria Oslash Oslashacute Otilde P Palochka-cy Pamphyliandigamma PdoubleStruck Pe-cy Pedescender-cy Pemiddlehook-cy Phi Pi Psi Psi-cy Q Qa-cy QdoubleStruck R Racute Rcaron Rcommaaccent RdoubleStruck Reversedze-cy Rha-cy Rho Rhodasia S SF010000 SF020000 SF030000 SF040000 SF050000 SF060000 SF070000 SF080000 SF090000 SF100000 SF110000 SF190000 SF200000 SF210000 SF220000 SF230000 SF240000 SF250000 SF260000 SF270000 SF280000 SF360000 SF370000 SF380000 SF390000 SF400000 SF410000 SF420000 SF430000 SF440000 SF450000 SF460000 SF470000 SF480000 SF490000 SF500000 SF510000 SF520000 SF530000 SF540000 Sacute Sacute.loclPLK Sampi San Scaron Scedilla Schwa-cy Schwadieresis-cy Scircumflex Scommaaccent Semisoftsign-cy Sha-cy Shcha-cy Shha-cy Shhadescender-cy Sho Sigma SigmaLunateDottedReversedSymbol SigmaLunateDottedSymbol SigmaLunateReversedSymbol SigmaLunateSymbol Softsign-cy Stigma T T.spacer T_l.liga.ss10 Tau Tbar Tcaron Tcedilla Tcommaaccent Te-cy Tedescender-cy Tetse-cy Theta ThetaSymbol Thorn Tse-cy Tshe-cy U U-cy Uacute Ubreve Ucircumflex Udieresis Udieresis-cy Ugrave Uhungarumlaut Uhungarumlaut-cy Uk-cy Umacron Umacron-cy Uogonek Upsilon UpsilonacutehookSymbol Upsilondasia Upsilondasiaoxia Upsilondasiaperispomeni Upsilondasiavaria Upsilondieresis UpsilondieresishookSymbol UpsilonhookSymbol Upsilonmacron Upsilonoxia Upsilontonos Upsilonvaria Upsilonvrachy Uring Ushort-cy Ustrait-cy Ustraitstroke-cy Utilde V Ve-cy W Wacute Wcircumflex Wdieresis We-cy Wgrave X Xi Y Yacute Yae-cy Yat-cy Ycircumflex Ydieresis Yeru-cy Yerudieresis-cy Ygrave Yi-cy Yot-greek Yusbig-cy Yusbigiotified-cy Yuslittle-cy Yuslittleiotified-cy Z Zacute Zacute.loclPLK Zcaron Zdotaccent ZdoubleStruck Ze-cy Zedescender-cy Zedieresis-cy Zeta Zhe-cy Zhebreve-cy Zhedescender-cy Zhedieresis-cy a a-cy a.cv01 aacute aacute.cv01 abreve abreve-cy abreve.cv01 acircumflex acircumflex.cv01 acknowledge-control acute acute.case acute.case.loclPLK acute.loclPLK acutecomb adieresis adieresis-cy adieresis.cv01 ae aeacute afii00208 agrave agrave.cv01 aie-cy aleutka-cy almostequalorequalto alpha alphadasia alphadasiaoxia alphadasiaoxiaypogegrammeni alphadasiaperispomeni alphadasiaperispomeniypogegrammeni alphadasiavaria alphadasiavariaypogegrammeni alphadasiaypogegrammeni alphamacron alphaoxia alphaoxiaypogegrammeni alphaperispomeni alphaperispomeniypogegrammeni alphapsili alphapsilioxia alphapsilioxiaypogegrammeni alphapsiliperispomeni alphapsiliperispomeniypogegrammeni alphapsilivaria alphapsilivariaypogegrammeni alphapsiliypogegrammeni alphatonos alphavaria alphavariaypogegrammeni alphavrachy alphaypogegrammeni alternativekeysymbol amacron amacron.cv01 ampersand ampersand.before.ss03 ampersand.spacer ampersand.ss03 ampersand_ampersand.liga anoteleia anticlockwiseGappedCircleArrow aogonek aogonek.cv01 apostrophemod approxequal approximatelybutnotactuallyequalto archaicsampi aring aring.cv01 arrowboth arrowdown arrowdownleft arrowdownright arrowdownwhite arrowleft arrowleftwhite arrowright arrowrightwhite arrowup arrowupdown arrowupleft arrowupright arrowupwhite asciicircum asciicircum.spacer asciicircum_equal.liga asciitilde asciitilde.cv17 asciitilde.spacer asciitilde_asciitilde.liga asciitilde_asciitilde_greater.liga asciitilde_at.liga asciitilde_greater.liga asciitilde_hyphen.liga assertion asterisk asterisk.cv15 asterisk.lc asterisk.spacer asterisk_asterisk.liga asterisk_asterisk.liga.cv16 asterisk_asterisk_asterisk.liga asterisk_asterisk_asterisk.liga.cv16 asterisk_greater.liga asterisk_greater.liga.cv16 asterisk_slash.liga asterisk_slash.liga.cv16 asteriskmath asteriskmath.cv15 asteriskmath.lc asymptoticallyequal at at.spacer at.ss05 atilde atilde.cv01 b backslash backslash.spacer backslash.ss06 backslash_slash.liga backspace-control ballotBox ballotBoxWithCheck ballotBoxWithX bar bar.cv30 bar.spacer bar_bar.liga bar_bar.liga.cv30 bar_bar_bar.liga bar_bar_bar.liga.cv30 bar_bar_bar_greater.liga bar_bar_equal_end.seq bar_bar_equal_end.seq.cv30 bar_bar_equal_middle.seq bar_bar_equal_middle.seq.cv30 bar_bar_equal_start.seq bar_bar_equal_start.seq.cv30 bar_bar_greater.liga bar_bar_hyphen_end.seq bar_bar_hyphen_end.seq.cv30 bar_bar_hyphen_middle.seq bar_bar_hyphen_middle.seq.cv30 bar_bar_hyphen_start.seq bar_bar_hyphen_start.seq.cv30 bar_braceright.liga bar_bracketright.liga bar_equal_end.seq bar_equal_end.seq.cv30 bar_equal_middle.seq bar_equal_middle.seq.cv30 bar_equal_start.seq bar_equal_start.seq.cv30 bar_greater.liga bar_hyphen_end.seq bar_hyphen_end.seq.cv30 bar_hyphen_middle.seq bar_hyphen_middle.seq.cv30 bar_hyphen_start.seq bar_hyphen_start.seq.cv30 bar_underscore_middle.seq bar_underscore_middle.seq.cv30 be-cy because bell-control beta betaSymbol blackCircle blackDiamond blackLowerLeftTriangle blackLowerRightTriangle blackRightArrow blackUpperLeftTriangle blackUpperRightTriangle blackVerticalRect blank blankSymbol boxDownHeavyAndHorizontalLight boxDownHeavyAndLeftLight boxDownHeavyAndLeftUpLight boxDownHeavyAndRightLight boxDownHeavyAndRightUpLight boxDownHeavyAndUpHorizontalLight boxDownLightAndHorizontalHeavy boxDownLightAndLeftHeavy boxDownLightAndLeftUpHeavy boxDownLightAndRightHeavy boxDownLightAndRightUpHeavy boxDownLightAndUpHorizontalHeavy boxHeavyDoubleDashHorizontal boxHeavyDoubleDashVertical boxHeavyDown boxHeavyDownAndHorizontal boxHeavyDownAndLeft boxHeavyDownAndRight boxHeavyHorizontal boxHeavyLeft boxHeavyLeftAndLightRight boxHeavyQuadrupleDashHorizontal boxHeavyQuadrupleDashVertical boxHeavyRight boxHeavyTripleDashHorizontal boxHeavyTripleDashVertical boxHeavyUp boxHeavyUpAndHorizontal boxHeavyUpAndLeft boxHeavyUpAndLightDown boxHeavyUpAndRight boxHeavyVertical boxHeavyVerticalAndHorizontal boxHeavyVerticalAndLeft boxHeavyVerticalAndRight boxLeftDownHeavyAndRightUpLight boxLeftHeavyAndRightDownLight boxLeftHeavyAndRightUpLight boxLeftHeavyAndRightVerticalLight boxLeftLightAndRightDownHeavy boxLeftLightAndRightUpHeavy boxLeftLightAndRightVerticalHeavy boxLeftUpHeavyAndRightDownLight boxLightDiagonalCross boxLightDiagonalUpperLeftToLowerRight boxLightDiagonalUpperRightToLowerLeft boxLightDoubleDashHorizontal boxLightDoubleDashVertical boxLightDown boxLightLeft boxLightLeftAndHeavyRight boxLightQuadrupleDashHorizontal boxLightQuadrupleDashVertical boxLightRight boxLightTripleDashHorizontal boxLightTripleDashVertical boxLightUp boxLightUpAndHeavyDown boxRightDownHeavyAndLeftUpLight boxRightHeavyAndLeftDownLight boxRightHeavyAndLeftUpLight boxRightHeavyAndLeftVerticalLight boxRightLightAndLeftDownHeavy boxRightLightAndLeftUpHeavy boxRightLightAndLeftVerticalHeavy boxRightUpHeavyAndLeftDownLight boxUpHeavyAndDownHorizontalLight boxUpHeavyAndHorizontalLight boxUpHeavyAndLeftDownLight boxUpHeavyAndLeftLight boxUpHeavyAndRightDownLight boxUpHeavyAndRightLight boxUpLightAndDownHorizontalHeavy boxUpLightAndHorizontalHeavy boxUpLightAndLeftDownHeavy boxUpLightAndLeftHeavy boxUpLightAndRightDownHeavy boxUpLightAndRightHeavy boxVerticalHeavyAndHorizontalLight boxVerticalHeavyAndLeftLight boxVerticalHeavyAndRightLight boxVerticalLightAndHorizontalHeavy boxVerticalLightAndLeftHeavy boxVerticalLightAndRightHeavy braceleft braceleft.case braceleft.cv29 braceleft.spacer braceleft_bar.liga braceright braceright.case braceright.cv29 braceright.spacer bracketleft bracketleft.case bracketleft.spacer bracketleft_bar.liga bracketleft_bracketright.cv27 bracketright bracketright.case bracketright.spacer bracketright_numbersign.liga breve breve-cy breve-cy.case breve.case brevecomb brokenCircleNorthWestArrow brokenbar bullet bulletoperator bullseye c cacute cacute.loclPLK canadiansyllabicsa canadiansyllabicso cancel-control capslock caron caron.alt caron.case caroncomb carriageReturn-control ccaron ccedilla ccircumflex cdotaccent cedilla cedilla.case cedillacomb cent che-cy cheabkhasian-cy checkmark chedescender-cy chedescenderabkhasian-cy chedieresis-cy chekhakassian-cy cheverticalstroke-cy chi circumflex circumflex.case circumflexcomb clear clockwiseGappedCircleArrow club colon colon.center colon.spacer colon.uc colon_colon.liga colon_colon_colon.liga colon_colon_equal.liga colon_equal.liga colon_equal_middle.seq colon_hyphen.cv26 comma commaabovecomb commaaccent commaaccent.case commareversedabovecomb congruent containsasmemberSmall control copyright cornerbracketleft cornerbracketleft.half cornerbracketright cornerbracketright.half crosshatchFillSquare curlybracketextension currency d dagger daggerdbl dasia dasiaoxia dasiaperispomeni dasiavaria dataLinkEscape-control dblgravecomb dblverticalbar dcaron dche-cy dcroat de-cy degree delete-control deleteFormTwo-control deleteLeftKey deleterightKey delta deviceControlFour-control deviceControlOne-control deviceControlThree-control deviceControlTwo-control diagonalcrosshatchFillSquare dialytikaoxia dialytikaperispomeni dialytikavaria diameterSign diamond dieresis dieresis.case dieresiscomb dieresistonos digamma divide divisionslash dje-cy dkshade doesnotforce doesnotprove dollar dollar.spacer dollar.ss04 dollar_greater.liga dollar_greater.liga.ss04 dotaccent dotaccent.case dotaccentcomb dotlessj dottedlunatesigmasymbol doubleprimemod doubleverticalbardoublerightturnstile downArrowHead downBlackArrow downBlock downQuadrupleArrow downTipLeftArrow downTipRightArrow drachma dze-cy dzeabkhasian-cy dzhe-cy dzzhe-cy e e-cy eacute earthTrigram ebreve ecaron ecircumflex edieresis edieresis-cy edotaccent ef-cy egrave eight eight.dnom eight.numr eight.tosf eightinferior eightsuperior eiotified-cy ejectsymbol el-cy eldescender-cy element elementSmall elhook-cy ellipsis elmiddlehook-cy eltail-cy em-cy emacron emdash emdash.case emptyset emtail-cy en-cy endOfMedium-control endOfText-control endOfTransmission-control endOfTransmissionBlock-control endash endash.case endescender-cy endofproof eng enghe-cy enhook-cy enlefthook-cy enmiddlehook-cy enquiry-control entail-cy eogonek epsilon epsilonLunateReversedSymbol epsilonLunateSymbol epsilondasia epsilondasiaoxia epsilondasiavaria epsilonoxia epsilonpsili epsilonpsilioxia epsilonpsilivaria epsilontonos epsilonvaria equal equal.dnom equal.numr equal.spacer equal_asciitilde.ss07 equal_end.seq equal_equal.liga equal_equal.ss08 equal_equal_equal.liga equal_equal_equal.ss08 equal_middle.seq equal_start.seq equals.circled equalsinferior equalsuperior equivalence er-cy ereversed-cy ertick-cy es-cy escape-control esdescender-cy estimated eta etadasia etadasiaoxia etadasiaoxiaypogegrammeni etadasiaperispomeni etadasiaperispomeniypogegrammeni etadasiavaria etadasiavariaypogegrammeni etadasiaypogegrammeni etaoxia etaoxiaypogegrammeni etaperispomeni etaperispomeniypogegrammeni etapsili etapsilioxia etapsilioxiaypogegrammeni etapsiliperispomeni etapsiliperispomeniypogegrammeni etapsilivaria etapsilivariaypogegrammeni etapsiliypogegrammeni etatonos etavaria etavariaypogegrammeni etaypogegrammeni eth euro exclam exclam.spacer exclam_asciitilde.ss07 exclam_equal.liga exclam_equal.ss08 exclam_equal_equal.liga exclam_equal_equal.ss08 exclam_equal_middle.seq exclam_exclam.liga exclam_exclam_period.liga exclamdown exclamdown.case existential f f.spacer f_i.liga.ss10 f_j.liga.ss10 f_l.liga.ss10 f_t.liga.ss10 female figuredash fileSeparator-control filledRect filledbox fireTrigram firsttonechinese fisheye fita-cy five five.dnom five.numr five.tosf fiveeighths fiveinferior fivesixths fivesuperior florin forces formFeed-control four four.dnom four.numr four.tosf fourfifths fourinferior foursuperior fraction fullBlock g g.cv02 gamma gbreve gbreve.cv02 gcircumflex gcircumflex.cv02 gcommaaccent gcommaaccent.cv02 gdotaccent gdotaccent.cv02 ge-cy gedescender-cy germandbls gestrokehook-cy ghemiddlehook-cy ghestroke-cy gheupturn-cy gje-cy globeWithMeridians gradient grave grave.case gravecomb greater greater.center greater.spacer greater_equal.liga greater_equal.ss02 greater_equal_end.seq greater_equal_middle.seq greater_equal_start.seq greater_greater.liga greater_greater_equal_end.seq greater_greater_equal_middle.seq greater_greater_equal_start.seq greater_greater_greater.liga greater_greater_hyphen_end.seq greater_greater_hyphen_middle.seq greater_greater_hyphen_start.seq greater_hyphen_end.seq greater_hyphen_middle.seq greater_hyphen_start.seq greaterequal groupSeparator-control guillemetleft guillemetleft.case guillemetright guillemetright.case guilsinglleft guilsinglleft.case guilsinglright guilsinglright.case h ha-cy haabkhasian-cy hadescender-cy hahook-cy hardsign-cy hastroke-cy hbar hcircumflex heart heavenTrigram heavyleftpointinganglebracketornament heavyrightpointinganglebracketornament helmsymbol heta horizontalFillSquare horizontalTabulation-control house hungarumlaut hungarumlaut.case hungarumlautcomb hyphen hyphen.case hyphen.lc hyphen.spacer hyphen_asciitilde.liga hyphen_end.seq hyphen_hyphen.liga hyphen_middle.seq hyphen_start.seq i i-cy i.cv03 i.cv04 i.cv05 i.cv06 i.salt_low ia-cy iacute iacute.cv03 iacute.cv04 iacute.cv05 iacute.cv06 ibreve ibreve.cv03 ibreve.cv04 ibreve.cv05 ibreve.cv06 icircumflex icircumflex.cv03 icircumflex.cv04 icircumflex.cv05 icircumflex.cv06 idieresis idieresis-cy idieresis.cv03 idieresis.cv04 idieresis.cv05 idieresis.cv06 idotaccent idotaccent.cv03 idotaccent.cv04 idotaccent.cv05 idotaccent.cv06 idotless idotless.cv03 idotless.cv04 idotless.cv05 idotless.cv06 ie-cy iebreve-cy iegrave-cy igrave igrave.cv03 igrave.cv04 igrave.cv05 igrave.cv06 ii-cy iigrave-cy iishort-cy iishorttail-cy ij imacron imacron-cy imacron.cv03 imacron.cv04 imacron.cv05 imacron.cv06 increment infinity infinity.case integral integralbt integraltp intersection inverseWhiteCircle invsmileface io-cy iogonek iogonek.cv03 iogonek.cv04 iogonek.cv05 iogonek.cv06 iota iotadasia iotadasiaoxia iotadasiaperispomeni iotadasiavaria iotadialytikaoxia iotadialytikaperispomeni iotadialytikavaria iotadieresis iotadieresistonos iotamacron iotaoxia iotaperispomeni iotapsili iotapsilioxia iotapsiliperispomeni iotapsilivaria iotatonos iotavaria iotavrachy itilde itilde.cv03 itilde.cv04 itilde.cv05 itilde.cv06 iu-cy izhitsa-cy izhitsadblgrave-cy j j.salt_low jcircumflex je-cy k ka-cy kabashkir-cy kadescender-cy kahook-cy kaiSymbol kappa kappaSymbol kastroke-cy kaverticalstroke-cy kcommaaccent keyboard kgreenlandic kje-cy komide-cy komidje-cy komidzje-cy komilje-cy kominje-cy komisje-cy komitje-cy komizje-cy koppa koppaArchaic koronis ksi-cy l l.cv07 l.cv08 l.cv09 l.cv10 l.salt_low l.spacer lacute lacute.cv07 lacute.cv08 lacute.cv09 lacute.cv10 lakeTrigram lambda largeCircle lcaron lcaron.cv07 lcaron.cv08 lcaron.cv09 lcaron.cv10 lcommaaccent lcommaaccent.cv07 lcommaaccent.cv08 lcommaaccent.cv09 lcommaaccent.cv10 ldot ldot.cv07 ldot.cv08 ldot.cv09 ldot.cv10 leftBlackArrow leftBlackTriangle leftBlock leftFiveEighthsBlock leftHalfBlackCircle leftHalfBlackSquare leftHalfBlackWhiteCircle leftHookArrow leftLongArrow leftLongDoubleArrow leftLongDoubleFromBarArrow leftLongFromBarArrow leftOneEighthBlock leftOneQuarterBlock leftRightLongArrow leftRightLongDoubleArrow leftSevenEighthsBlock leftTabArrow leftThreeEighthsBlock leftThreeQuartersBlock leftanglebracket-math leftcurlybracketlowerhook leftcurlybracketmiddlepiece leftcurlybracketupperhook leftsquarebracketextension leftsquarebracketlowercorner leftsquarebracketuppercorner less less.center less.spacer less_asciitilde.liga less_asciitilde_asciitilde.liga less_asciitilde_greater.liga less_asterisk.liga less_asterisk.liga.cv16 less_asterisk_greater.liga less_asterisk_greater.liga.cv16 less_bar.liga less_bar_bar.liga less_bar_bar_bar.liga less_bar_greater.liga less_dollar.liga less_dollar.liga.ss04 less_dollar_greater.liga less_dollar_greater.liga.ss04 less_equal.liga less_equal.ss02 less_equal_end.seq less_equal_middle.seq less_equal_start.seq less_exclam_hyphen_hyphen.liga less_greater.liga less_hyphen_end.seq less_hyphen_middle.seq less_hyphen_start.seq less_less.liga less_less_equal_end.seq less_less_equal_middle.seq less_less_equal_start.seq less_less_hyphen_end.seq less_less_hyphen_middle.seq less_less_hyphen_start.seq less_less_less.liga less_plus.liga less_plus_greater.liga less_slash.liga less_slash_greater.liga lessequal lha-cy lineFeed-control liraTurkish literSign lje-cy logicaland logicalnot logicalor lowerFiveEighthsBlock lowerHalfArc lowerHalfBlackWhiteCircle lowerHalfInverseWhiteCircle lowerLeftArc lowerLeftQuadrantWhiteCircle lowerOneEighthBlock lowerOneQuarterBlock lowerRightArc lowerRightDiagonalHalfBlackSquare lowerRightQuadrantWhiteCircle lowerSevenEighthsBlock lowerThreeEighthsBlock lowerThreeQuartersBlock lowernumeral-greek lozenge lslash lslash.cv07 lslash.cv08 lslash.cv09 lslash.cv10 ltshade m macron macron.case macroncomb male micro minus minus.dnom minus.numr minusinferior minussuperior minustilde models mountainTrigram mu multiply musicalnote musicalnotedbl n nacute nacute.loclPLK napostrophe ncaron ncommaaccent negateddoubleverticalbardoublerightturnstile negativeAcknowledge-control neitherapproximatelynoractuallyequalto neitherasubsetofnorequalto neitherasupersetofnorequalto newline-control nine nine.dnom nine.numr nine.tosf nineinferior ninesuperior nje-cy nmod notalmostequalto notasymptoticallyequalto notcontains notelement notequal notidentical notsimilar notsubset notsuperset nottrue ntilde nu null null-control numbersign numbersign.spacer numbersign_braceleft.liga numbersign_braceleft.liga.cv29 numbersign_bracketleft.liga numbersign_colon.liga numbersign_colon.liga_rem numbersign_end.seq numbersign_equal.liga numbersign_exclam.liga numbersign_middle.seq numbersign_parenleft.liga numbersign_question.liga numbersign_start.seq numbersign_underscore.liga numbersign_underscore_parenleft.liga numeral-greek numero o o-cy oacute oacute.loclPLK obarred-cy obarreddieresis-cy obreve ocircumflex odieresis odieresis-cy oe ogonek ograve ohungarumlaut omacron omega omega-cy omegadasia omegadasiaoxia omegadasiaoxiaypogegrammeni omegadasiaperispomeni omegadasiaperispomeniypogegrammeni omegadasiavaria omegadasiavariaypogegrammeni omegadasiaypogegrammeni omegaoxia omegaoxiaypogegrammeni omegaperispomeni omegaperispomeniypogegrammeni omegapsili omegapsilioxia omegapsilioxiaypogegrammeni omegapsiliperispomeni omegapsiliperispomeniypogegrammeni omegapsilivaria omegapsilivariaypogegrammeni omegapsiliypogegrammeni omegatonos omegavaria omegavariaypogegrammeni omegaypogegrammeni omicron omicrondasia omicrondasiaoxia omicrondasiavaria omicronoxia omicronpsili omicronpsilioxia omicronpsilivaria omicrontonos omicronvaria one one.dnom one.numr one.tosf oneeighth onefifth onefraction onehalf oneinferior onequarter onesixth onesuperior onethird optionKey ordfeminine ordmasculine oslash oslashacute otilde overlinecomb oxia oxia.case p pagedown pageup palochka-cy pamphyliandigamma paragraph parenleft parenleft.case parenleft.cv31 parenleft.dnom parenleft.numr parenleft.spacer parenleftextension parenleftinferior parenleftlowerhook parenleftsuperior parenleftupperhook parenright parenright.case parenright.cv31 parenright.dnom parenright.numr parenrightextension parenrightinferior parenrightlowerhook parenrightsuperior parenrightupperhook partialdiff pe-cy pedescender-cy pemiddlehook-cy percent percent.cv18 percent.spacer percent_percent.liga percent_percent.liga.cv18 period period.spacer period_equal.cv32 period_hyphen.cv25 period_period.liga period_period_equal.liga period_period_less.liga period_period_period.liga period_question.liga periodcentered perispomeni perispomenicomb perspective perthousand perthousand.cv18 phi phiSymbol pi piSymbol plus plus.dnom plus.lc plus.numr plus.spacer plus_greater.liga plus_plus.liga plus_plus_plus.liga plusinferior plusminus plussuperior primemod product projective propellor proportion prosgegrammeni psi psi-cy psili psilioxia psiliperispomeni psilivaria q qa-cy quadrantLowerLeft quadrantLowerRight quadrantUpperLeft quadrantUpperLeftAndLowerLeftAndLowerRight quadrantUpperLeftAndLowerRight quadrantUpperLeftAndUpperRightAndLowerLeft quadrantUpperLeftAndUpperRightAndLowerRight quadrantUpperRight quadrantUpperRightAndLowerLeft quadrantUpperRightAndLowerLeftAndLowerRight question question.spacer question_equal.liga question_period.liga question_question.liga questiondown questiondown.case questiongreek quotedbl quotedblbase quotedblleft quotedblright quoteleft quoteright quotesinglbase quotesingle r r.ss01 racute radical ratio rcaron rcommaaccent recordSeparator-control reflexsubset reflexsuperset registered replacementCharacter returnsymbol reverseddottedlunatesigmasymbol reversedlunatesigmasymbol reversedze-cy revlogicalnot rha-cy rho rhoStrokeSymbol rhoSymbol rhodasia rhopsili rightBlackTriangle rightBlock rightCircledPlusArrow rightHalfBlackCircle rightHalfBlackSquare rightHalfBlackWhiteCircle rightHookArrow rightLongDoubleArrow rightLongDoubleFromBarArrow rightLongFromBarArrow rightLongSquiggleArrow rightOneEighthBlock rightTabArrow rightanglebracket-math rightcurlybracketlowerhook rightcurlybracketmiddlepiece rightcurlybracketupperhook rightlongArrow rightsquarebracketextension rightsquarebracketlowercorner rightsquarebracketuppercorner righttack ring ring.case ringcomb ruble rupeeIndian s sacute sacute.loclPLK sampi san scaron scedilla schwa-cy schwadieresis-cy scircumflex scommaaccent section semicolon semicolon.spacer semicolon_semicolon.liga semisoftsign-cy seven seven.dnom seven.numr seven.tosf seveneighths seveninferior sevensuperior sha-cy shade shcha-cy shha-cy shhadescender-cy shiftIn-control shiftOut-control sho sigma sigmaLunateSymbol sigmafinal six six.dnom six.numr six.tosf sixinferior sixsuperior skullAndCrossbones slash slash.spacer slash_asterisk.liga slash_asterisk.liga.cv16 slash_backslash.liga slash_equal_end.seq slash_equal_middle.seq slash_equal_start.seq slash_greater.liga slash_slash.liga slash_slash_equal_end.seq slash_slash_equal_middle.seq slash_slash_equal_start.seq slash_slash_slash.liga smileface softhyphen softhyphen.case softsign-cy space-control spade squarewhitewithsmallblack startOfHeading-control startOfText-control sterling stigma strokelongoverlay strokeshortoverlay subset subsetnotequal substitute-control substituteFormTwo-control suchthat summation sun superset supersetnotequal synchronousIdle-control t tackdown tackleft tau tbar tcaron tcedilla tcommaaccent te-cy tedescender-cy tetse-cy theredoesnotexist therefore theta thetaSymbol thorn three three.cv14 three.cv14.dnom three.cv14.numr three.dnom three.dnom.cv14 three.numr three.numr.cv14 three.tosf three.tosf.cv14 threeTurned threeeighths threeemdash threefifths threeinferior threeinferior.cv14 threequarters threesuperior threesuperior.cv14 thunderTrigram tilde tilde.case tildecomb tironiansignet tonos tonos.case trademark triaglf triagupTriangle triangledown triangleright tripletilde tripleverticalbarrightturnstile true tse-cy tshe-cy two two.dnom two.numr two.tosf twoTurned twoemdash twofifths twoinferior twosuperior twothirds u u-cy u1F10D u1F10E u1F10F u1F16D u1F16E u1F16F u1F1AD uacute ubreve ucircumflex udieresis udieresis-cy ugrave uhungarumlaut uhungarumlaut-cy uk-cy umacron umacron-cy underscore underscore.spacer underscore_end.seq underscore_middle.seq underscore_start.seq underscoredbl uni256D uni256E uni256F uni2570 uniE000 uniE001 uniE002 uniE003 uniE0A0 uniE0A1 uniE0A2 uniE0B0 uniE0B1 uniE0B2 uniE0B3 uniEE00 uniEE01 uniEE02 uniEE03 uniEE04 uniEE05 uniEE06 uniEE07 uniEE08 uniEE09 uniEE0A uniEE0B uniFEFF union unitSeparator-control universal uogonek upBetweenTwoHorizontalBarsArrowHead upBlackArrow upBlock upQuadrupleArrow upTipLeftArrow upTipRightArrow upperHalfArc upperHalfBlackWhiteCircle upperHalfInverseWhiteCircle upperLeftArc upperLeftDiagonalHalfBlackSquare upperLeftQuadrantWhiteCircle upperLeftWhiteCircle upperOneEighthBlock upperRightArc upperRightQuadrantWhiteCircle upperlefttolowerrightFillSquare upperrighttolowerleftFillSquare upsilon upsilondasia upsilondasiaoxia upsilondasiaperispomeni upsilondasiavaria upsilondialytikaoxia upsilondialytikaperispomeni upsilondialytikavaria upsilondieresis upsilondieresistonos upsilonmacron upsilonoxia upsilonperispomeni upsilonpsili upsilonpsilioxia upsilonpsiliperispomeni upsilonpsilivaria upsilontonos upsilonvaria upsilonvrachy uptack uring ushort-cy ustrait-cy ustraitstroke-cy utilde v varia varia.case ve-cy verticalBisectingLineWhiteSquare verticalFillSquare verticalTabulation-control w w.spacer w_w_w.liga wacute waterTrigram wcircumflex wdieresis we-cy wgrave whiteCircle whiteDiamond whiteFrowningFace whiteRect whiteSquareWithLowerLeftQuadrant whiteSquareWithLowerRightQuadrant whiteSquareWithRoundedCorners whiteSquareWithUpperLeftQuadrant whiteSquareWithUpperRightQuadrant whiteVerticalRect windTrigram x x.multiply x.multiply.tosf xi y yacute yae-cy yat-cy ycircumflex ydieresis yen yeru-cy yerudieresis-cy ygrave yi-cy yot ypogegrammeni ypogegrammenicomb yusbig-cy yusbigiotified-cy yuslittle-cy yuslittleiotified-cy z zacute zacute.loclPLK zcaron zdotaccent ze-cy zedescender-cy zedieresis-cy zero zero.cv11 zero.cv12 zero.cv13 zero.dnom zero.numr zero.tosf zero.tosf.cv11 zero.tosf.cv12 zero.tosf.cv13 zero.tosf.zero zero.zero zero.zero.tosf zeroinferior zerosuperior zeta zhe-cy zhebreve-cy zhedescender-cy zhedieresis-cy";
@@ -119547,6 +119544,100 @@ unicode = 251D;
 },
 {
 color = 3;
+glyphname = "horizontalOneEighthBlock-1358";
+lastChange = "2023-12-31 14:08:06 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 1500 LINE",
+"1200 1500 LINE",
+"1200 1800 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 1200 LINE",
+"0 900 LINE",
+"1200 900 LINE",
+"1200 1200 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 600 LINE",
+"0 300 LINE",
+"1200 300 LINE",
+"1200 600 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 -300 LINE",
+"0 -600 LINE",
+"1200 -600 LINE",
+"1200 -300 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 1500 LINE",
+"1200 1500 LINE",
+"1200 1800 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 1200 LINE",
+"0 900 LINE",
+"1200 900 LINE",
+"1200 1200 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 600 LINE",
+"0 300 LINE",
+"1200 300 LINE",
+"1200 600 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 -300 LINE",
+"0 -600 LINE",
+"1200 -600 LINE",
+"1200 -300 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB81;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
 glyphname = "horizontalOneEighthBlock-2";
 lastChange = "2023-12-31 13:49:45 +0000";
 layers = (
@@ -119963,6 +120054,206 @@ subCategory = Geometry;
 },
 {
 color = 3;
+glyphname = rightFiveEighthsBlock;
+lastChange = "2023-12-31 14:22:13 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"450 1800 LINE",
+"450 -600 LINE",
+"1200 -600 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"450 1800 LINE",
+"450 -600 LINE",
+"1200 -600 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB89;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = rightOneQuarterBlock;
+lastChange = "2023-12-31 14:17:35 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"900 1800 LINE",
+"900 -600 LINE",
+"1200 -600 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"900 1800 LINE",
+"900 -600 LINE",
+"1200 -600 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB87;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = rightSevenEighthsBlock;
+lastChange = "2023-12-31 14:23:03 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"150 1800 LINE",
+"150 -600 LINE",
+"1200 -600 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"150 1800 LINE",
+"150 -600 LINE",
+"1200 -600 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB8B;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = rightThreeEighthsBlock;
+lastChange = "2023-12-31 14:20:21 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"750 1800 LINE",
+"750 -600 LINE",
+"1200 -600 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"750 1800 LINE",
+"750 -600 LINE",
+"1200 -600 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB88;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = rightThreeQuartersBlock;
+lastChange = "2023-12-31 14:18:53 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"300 1800 LINE",
+"300 -600 LINE",
+"1200 -600 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"300 1800 LINE",
+"300 -600 LINE",
+"1200 -600 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB8A;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
 glyphname = uni256D;
 lastChange = "2020-04-05 21:57:02 +0000";
 layers = (
@@ -120241,6 +120532,46 @@ subCategory = Geometry;
 },
 {
 color = 3;
+glyphname = upperFiveEighthsBlock;
+lastChange = "2023-12-31 14:11:52 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 300 LINE",
+"1200 300 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 300 LINE",
+"1200 300 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB84;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
 glyphname = upperOneQuarterBlock;
 lastChange = "2023-12-31 13:46:42 +0000";
 layers = (
@@ -120276,6 +120607,126 @@ width = 1200;
 }
 );
 unicode = 1FB82;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = upperSevenEighthsBlock;
+lastChange = "2023-12-31 14:14:43 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 -300 LINE",
+"1200 -300 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 -300 LINE",
+"1200 -300 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB86;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = upperThreeEighthsBlock;
+lastChange = "2023-12-31 14:10:50 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 900 LINE",
+"1200 900 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 900 LINE",
+"1200 900 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB83;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = upperThreeQuartersBlock;
+lastChange = "2023-12-31 14:13:52 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 0 LINE",
+"1200 0 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 0 LINE",
+"1200 0 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB85;
 category = Symbol;
 subCategory = Geometry;
 },
@@ -129572,97 +130023,6 @@ nodes = (
 "333 1370 OFFCURVE",
 "464 1314 OFFCURVE",
 "597 1314 CURVE SMOOTH"
-);
-}
-);
-width = 1200;
-}
-);
-},
-{
-color = 3;
-glyphname = "horizontalOneEighthBlock-1358";
-lastChange = "2023-12-31 14:07:49 +0000";
-layers = (
-{
-layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
-paths = (
-{
-closed = 1;
-nodes = (
-"0 1800 LINE",
-"0 1500 LINE",
-"1200 1500 LINE",
-"1200 1800 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"0 1200 LINE",
-"0 900 LINE",
-"1200 900 LINE",
-"1200 1200 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"0 600 LINE",
-"0 300 LINE",
-"1200 300 LINE",
-"1200 600 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"0 -300 LINE",
-"0 -600 LINE",
-"1200 -600 LINE",
-"1200 -300 LINE"
-);
-}
-);
-width = 1200;
-},
-{
-layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
-paths = (
-{
-closed = 1;
-nodes = (
-"0 1800 LINE",
-"0 1500 LINE",
-"1200 1500 LINE",
-"1200 1800 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"0 1200 LINE",
-"0 900 LINE",
-"1200 900 LINE",
-"1200 1200 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"0 600 LINE",
-"0 300 LINE",
-"1200 300 LINE",
-"1200 600 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"0 -300 LINE",
-"0 -600 LINE",
-"1200 -600 LINE",
-"1200 -300 LINE"
 );
 }
 );

--- a/FiraCode.glyphs
+++ b/FiraCode.glyphs
@@ -1,5 +1,8 @@
 {
 .appVersion = "3108";
+DisplayStrings = (
+"/lowerOneEighthBlock"
+);
 classes = (
 {
 code = "A A-cy AE AEacute Aacute Abreve Abreve-cy Acircumflex Adieresis Adieresis-cy Agrave Aie-cy Aleutka-cy Alpha Alphadasia Alphadasiaoxia Alphadasiaoxiaprosgegrammeni Alphadasiaperispomeni Alphadasiaperispomeniprosgegrammeni Alphadasiaprosgegrammeni Alphadasiavaria Alphadasiavariaprosgegrammeni Alphamacron Alphaoxia Alphaprosgegrammeni Alphapsili Alphapsilioxia Alphapsilioxiaprosgegrammeni Alphapsiliperispomeni Alphapsiliperispomeniprosgegrammeni Alphapsiliprosgegrammeni Alphapsilivaria Alphapsilivariaprosgegrammeni Alphatonos Alphavaria Alphavrachy Amacron Aogonek Archaicsampi Aring Atilde B BdoubleStruck Be-cy Beta C CR Cacute Cacute.loclPLK Ccaron Ccedilla Ccircumflex Cdotaccent CdoubleStruck Che-cy Cheabkhasian-cy Chedescender-cy Chedescenderabkhasian-cy Chedieresis-cy Chekhakassian-cy Cheverticalstroke-cy Chi D Dcaron Dche-cy Dcroat De-cy Delta Digamma Dje-cy Dze-cy Dzeabkhasian-cy Dzhe-cy Dzzhe-cy E E-cy Eacute Ebreve Ecaron Ecircumflex Edieresis Edieresis-cy Edotaccent Ef-cy Egrave Eiotified-cy El-cy Eldescender-cy Elhook-cy Elmiddlehook-cy Eltail-cy Em-cy Emacron Emtail-cy En-cy EnLeftHook-cy Endescender-cy Eng Enghe-cy Enhook-cy Enmiddlehook-cy Entail-cy Eogonek Epsilon Epsilondasia Epsilondasiaoxia Epsilondasiavaria Epsilonoxia Epsilonpsili Epsilonpsilioxia Epsilonpsilivaria Epsilontonos Epsilonvaria Er-cy Ereversed-cy Ertick-cy Es-cy Esdescender-cy Eta Etadasia Etadasiaoxia Etadasiaoxiaprosgegrammeni Etadasiaperispomeni Etadasiaperispomeniprosgegrammeni Etadasiaprosgegrammeni Etadasiavaria Etadasiavariaprosgegrammeni Etaoxia Etaprosgegrammeni Etapsili Etapsilioxia Etapsilioxiaprosgegrammeni Etapsiliperispomeni Etapsiliperispomeniprosgegrammeni Etapsiliprosgegrammeni Etapsilivaria Etapsilivariaprosgegrammeni Etatonos Etavaria Eth F F.spacer F_l.liga.ss10 Fita-cy G Gamma Gbreve Gcircumflex Gcommaaccent Gdotaccent Ge-cy Gedescender-cy Germandbls Gestrokehook-cy Ghemiddlehook-cy Ghestroke-cy Gheupturn-cy Gje-cy H H18543 H18551 H22073 Ha-cy Haabkhasian-cy Hadescender-cy Hahook-cy Hardsign-cy Hastroke-cy Hbar Hcircumflex HdoubleStruck Heta I I-cy IJ Ia-cy Iacute Ibreve Icircumflex Idieresis Idieresis-cy Idotaccent Ie-cy Iebreve-cy Iegrave-cy Igrave Ii-cy Iigrave-cy Iishort-cy Iishorttail-cy Imacron Imacron-cy Io-cy Iogonek Iota Iotadasia Iotadasiaoxia Iotadasiaperispomeni Iotadasiavaria Iotadieresis Iotamacron Iotaoxia Iotapsili Iotapsilioxia Iotapsiliperispomeni Iotapsilivaria Iotatonos Iotavaria Iotavrachy Itilde Iu-cy Izhitsa-cy Izhitsadblgrave-cy J Jcircumflex Je-cy K Ka-cy Kabashkir-cy Kadescender-cy Kahook-cy KaiSymbol Kappa Kastroke-cy Kaverticalstroke-cy Kcommaaccent Kje-cy Komide-cy Komidje-cy Komidzje-cy Komilje-cy Kominje-cy Komisje-cy Komitje-cy Komizje-cy Koppa KoppaArchaic Ksi-cy L LIG Lacute Lambda Lcaron Lcommaaccent Ldot Lha-cy Lje-cy Lslash M Mu N Nacute Nacute.loclPLK Ncaron Ncommaaccent NdoubleStruck Nje-cy Ntilde Nu O O-cy OE Oacute Oacute.loclPLK Obarred-cy Obarreddieresis-cy Obreve Ocircumflex Odieresis Odieresis-cy Ograve Ohungarumlaut Omacron Omega Omega-cy Omegadasia Omegadasiaoxia Omegadasiaoxiaprosgegrammeni Omegadasiaperispomeni Omegadasiaperispomeniprosgegrammeni Omegadasiaprosgegrammeni Omegadasiavaria Omegadasiavariaprosgegrammeni Omegaoxia Omegaprosgegrammeni Omegapsili Omegapsilioxia Omegapsilioxiaprosgegrammeni Omegapsiliperispomeni Omegapsiliperispomeniprosgegrammeni Omegapsiliprosgegrammeni Omegapsilivaria Omegapsilivariaprosgegrammeni Omegatonos Omegavaria Omicron Omicrondasia Omicrondasiaoxia Omicrondasiavaria Omicronoxia Omicronpsili Omicronpsilioxia Omicronpsilivaria Omicrontonos Omicronvaria Oslash Oslashacute Otilde P Palochka-cy Pamphyliandigamma PdoubleStruck Pe-cy Pedescender-cy Pemiddlehook-cy Phi Pi Psi Psi-cy Q Qa-cy QdoubleStruck R Racute Rcaron Rcommaaccent RdoubleStruck Reversedze-cy Rha-cy Rho Rhodasia S SF010000 SF020000 SF030000 SF040000 SF050000 SF060000 SF070000 SF080000 SF090000 SF100000 SF110000 SF190000 SF200000 SF210000 SF220000 SF230000 SF240000 SF250000 SF260000 SF270000 SF280000 SF360000 SF370000 SF380000 SF390000 SF400000 SF410000 SF420000 SF430000 SF440000 SF450000 SF460000 SF470000 SF480000 SF490000 SF500000 SF510000 SF520000 SF530000 SF540000 Sacute Sacute.loclPLK Sampi San Scaron Scedilla Schwa-cy Schwadieresis-cy Scircumflex Scommaaccent Semisoftsign-cy Sha-cy Shcha-cy Shha-cy Shhadescender-cy Sho Sigma SigmaLunateDottedReversedSymbol SigmaLunateDottedSymbol SigmaLunateReversedSymbol SigmaLunateSymbol Softsign-cy Stigma T T.spacer T_l.liga.ss10 Tau Tbar Tcaron Tcedilla Tcommaaccent Te-cy Tedescender-cy Tetse-cy Theta ThetaSymbol Thorn Tse-cy Tshe-cy U U-cy Uacute Ubreve Ucircumflex Udieresis Udieresis-cy Ugrave Uhungarumlaut Uhungarumlaut-cy Uk-cy Umacron Umacron-cy Uogonek Upsilon UpsilonacutehookSymbol Upsilondasia Upsilondasiaoxia Upsilondasiaperispomeni Upsilondasiavaria Upsilondieresis UpsilondieresishookSymbol UpsilonhookSymbol Upsilonmacron Upsilonoxia Upsilontonos Upsilonvaria Upsilonvrachy Uring Ushort-cy Ustrait-cy Ustraitstroke-cy Utilde V Ve-cy W Wacute Wcircumflex Wdieresis We-cy Wgrave X Xi Y Yacute Yae-cy Yat-cy Ycircumflex Ydieresis Yeru-cy Yerudieresis-cy Ygrave Yi-cy Yot-greek Yusbig-cy Yusbigiotified-cy Yuslittle-cy Yuslittleiotified-cy Z Zacute Zacute.loclPLK Zcaron Zdotaccent ZdoubleStruck Ze-cy Zedescender-cy Zedieresis-cy Zeta Zhe-cy Zhebreve-cy Zhedescender-cy Zhedieresis-cy a a-cy a.cv01 aacute aacute.cv01 abreve abreve-cy abreve.cv01 acircumflex acircumflex.cv01 acknowledge-control acute acute.case acute.case.loclPLK acute.loclPLK acutecomb adieresis adieresis-cy adieresis.cv01 ae aeacute afii00208 agrave agrave.cv01 aie-cy aleutka-cy almostequalorequalto alpha alphadasia alphadasiaoxia alphadasiaoxiaypogegrammeni alphadasiaperispomeni alphadasiaperispomeniypogegrammeni alphadasiavaria alphadasiavariaypogegrammeni alphadasiaypogegrammeni alphamacron alphaoxia alphaoxiaypogegrammeni alphaperispomeni alphaperispomeniypogegrammeni alphapsili alphapsilioxia alphapsilioxiaypogegrammeni alphapsiliperispomeni alphapsiliperispomeniypogegrammeni alphapsilivaria alphapsilivariaypogegrammeni alphapsiliypogegrammeni alphatonos alphavaria alphavariaypogegrammeni alphavrachy alphaypogegrammeni alternativekeysymbol amacron amacron.cv01 ampersand ampersand.before.ss03 ampersand.spacer ampersand.ss03 ampersand_ampersand.liga anoteleia anticlockwiseGappedCircleArrow aogonek aogonek.cv01 apostrophemod approxequal approximatelybutnotactuallyequalto archaicsampi aring aring.cv01 arrowboth arrowdown arrowdownleft arrowdownright arrowdownwhite arrowleft arrowleftwhite arrowright arrowrightwhite arrowup arrowupdown arrowupleft arrowupright arrowupwhite asciicircum asciicircum.spacer asciicircum_equal.liga asciitilde asciitilde.cv17 asciitilde.spacer asciitilde_asciitilde.liga asciitilde_asciitilde_greater.liga asciitilde_at.liga asciitilde_greater.liga asciitilde_hyphen.liga assertion asterisk asterisk.cv15 asterisk.lc asterisk.spacer asterisk_asterisk.liga asterisk_asterisk.liga.cv16 asterisk_asterisk_asterisk.liga asterisk_asterisk_asterisk.liga.cv16 asterisk_greater.liga asterisk_greater.liga.cv16 asterisk_slash.liga asterisk_slash.liga.cv16 asteriskmath asteriskmath.cv15 asteriskmath.lc asymptoticallyequal at at.spacer at.ss05 atilde atilde.cv01 b backslash backslash.spacer backslash.ss06 backslash_slash.liga backspace-control ballotBox ballotBoxWithCheck ballotBoxWithX bar bar.cv30 bar.spacer bar_bar.liga bar_bar.liga.cv30 bar_bar_bar.liga bar_bar_bar.liga.cv30 bar_bar_bar_greater.liga bar_bar_equal_end.seq bar_bar_equal_end.seq.cv30 bar_bar_equal_middle.seq bar_bar_equal_middle.seq.cv30 bar_bar_equal_start.seq bar_bar_equal_start.seq.cv30 bar_bar_greater.liga bar_bar_hyphen_end.seq bar_bar_hyphen_end.seq.cv30 bar_bar_hyphen_middle.seq bar_bar_hyphen_middle.seq.cv30 bar_bar_hyphen_start.seq bar_bar_hyphen_start.seq.cv30 bar_braceright.liga bar_bracketright.liga bar_equal_end.seq bar_equal_end.seq.cv30 bar_equal_middle.seq bar_equal_middle.seq.cv30 bar_equal_start.seq bar_equal_start.seq.cv30 bar_greater.liga bar_hyphen_end.seq bar_hyphen_end.seq.cv30 bar_hyphen_middle.seq bar_hyphen_middle.seq.cv30 bar_hyphen_start.seq bar_hyphen_start.seq.cv30 bar_underscore_middle.seq bar_underscore_middle.seq.cv30 be-cy because bell-control beta betaSymbol blackCircle blackDiamond blackLowerLeftTriangle blackLowerRightTriangle blackRightArrow blackUpperLeftTriangle blackUpperRightTriangle blackVerticalRect blank blankSymbol boxDownHeavyAndHorizontalLight boxDownHeavyAndLeftLight boxDownHeavyAndLeftUpLight boxDownHeavyAndRightLight boxDownHeavyAndRightUpLight boxDownHeavyAndUpHorizontalLight boxDownLightAndHorizontalHeavy boxDownLightAndLeftHeavy boxDownLightAndLeftUpHeavy boxDownLightAndRightHeavy boxDownLightAndRightUpHeavy boxDownLightAndUpHorizontalHeavy boxHeavyDoubleDashHorizontal boxHeavyDoubleDashVertical boxHeavyDown boxHeavyDownAndHorizontal boxHeavyDownAndLeft boxHeavyDownAndRight boxHeavyHorizontal boxHeavyLeft boxHeavyLeftAndLightRight boxHeavyQuadrupleDashHorizontal boxHeavyQuadrupleDashVertical boxHeavyRight boxHeavyTripleDashHorizontal boxHeavyTripleDashVertical boxHeavyUp boxHeavyUpAndHorizontal boxHeavyUpAndLeft boxHeavyUpAndLightDown boxHeavyUpAndRight boxHeavyVertical boxHeavyVerticalAndHorizontal boxHeavyVerticalAndLeft boxHeavyVerticalAndRight boxLeftDownHeavyAndRightUpLight boxLeftHeavyAndRightDownLight boxLeftHeavyAndRightUpLight boxLeftHeavyAndRightVerticalLight boxLeftLightAndRightDownHeavy boxLeftLightAndRightUpHeavy boxLeftLightAndRightVerticalHeavy boxLeftUpHeavyAndRightDownLight boxLightDiagonalCross boxLightDiagonalUpperLeftToLowerRight boxLightDiagonalUpperRightToLowerLeft boxLightDoubleDashHorizontal boxLightDoubleDashVertical boxLightDown boxLightLeft boxLightLeftAndHeavyRight boxLightQuadrupleDashHorizontal boxLightQuadrupleDashVertical boxLightRight boxLightTripleDashHorizontal boxLightTripleDashVertical boxLightUp boxLightUpAndHeavyDown boxRightDownHeavyAndLeftUpLight boxRightHeavyAndLeftDownLight boxRightHeavyAndLeftUpLight boxRightHeavyAndLeftVerticalLight boxRightLightAndLeftDownHeavy boxRightLightAndLeftUpHeavy boxRightLightAndLeftVerticalHeavy boxRightUpHeavyAndLeftDownLight boxUpHeavyAndDownHorizontalLight boxUpHeavyAndHorizontalLight boxUpHeavyAndLeftDownLight boxUpHeavyAndLeftLight boxUpHeavyAndRightDownLight boxUpHeavyAndRightLight boxUpLightAndDownHorizontalHeavy boxUpLightAndHorizontalHeavy boxUpLightAndLeftDownHeavy boxUpLightAndLeftHeavy boxUpLightAndRightDownHeavy boxUpLightAndRightHeavy boxVerticalHeavyAndHorizontalLight boxVerticalHeavyAndLeftLight boxVerticalHeavyAndRightLight boxVerticalLightAndHorizontalHeavy boxVerticalLightAndLeftHeavy boxVerticalLightAndRightHeavy braceleft braceleft.case braceleft.cv29 braceleft.spacer braceleft_bar.liga braceright braceright.case braceright.cv29 braceright.spacer bracketleft bracketleft.case bracketleft.spacer bracketleft_bar.liga bracketleft_bracketright.cv27 bracketright bracketright.case bracketright.spacer bracketright_numbersign.liga breve breve-cy breve-cy.case breve.case brevecomb brokenCircleNorthWestArrow brokenbar bullet bulletoperator bullseye c cacute cacute.loclPLK canadiansyllabicsa canadiansyllabicso cancel-control capslock caron caron.alt caron.case caroncomb carriageReturn-control ccaron ccedilla ccircumflex cdotaccent cedilla cedilla.case cedillacomb cent che-cy cheabkhasian-cy checkmark chedescender-cy chedescenderabkhasian-cy chedieresis-cy chekhakassian-cy cheverticalstroke-cy chi circumflex circumflex.case circumflexcomb clear clockwiseGappedCircleArrow club colon colon.center colon.spacer colon.uc colon_colon.liga colon_colon_colon.liga colon_colon_equal.liga colon_equal.liga colon_equal_middle.seq colon_hyphen.cv26 comma commaabovecomb commaaccent commaaccent.case commareversedabovecomb congruent containsasmemberSmall control copyright cornerbracketleft cornerbracketleft.half cornerbracketright cornerbracketright.half crosshatchFillSquare curlybracketextension currency d dagger daggerdbl dasia dasiaoxia dasiaperispomeni dasiavaria dataLinkEscape-control dblgravecomb dblverticalbar dcaron dche-cy dcroat de-cy degree delete-control deleteFormTwo-control deleteLeftKey deleterightKey delta deviceControlFour-control deviceControlOne-control deviceControlThree-control deviceControlTwo-control diagonalcrosshatchFillSquare dialytikaoxia dialytikaperispomeni dialytikavaria diameterSign diamond dieresis dieresis.case dieresiscomb dieresistonos digamma divide divisionslash dje-cy dkshade doesnotforce doesnotprove dollar dollar.spacer dollar.ss04 dollar_greater.liga dollar_greater.liga.ss04 dotaccent dotaccent.case dotaccentcomb dotlessj dottedlunatesigmasymbol doubleprimemod doubleverticalbardoublerightturnstile downArrowHead downBlackArrow downBlock downQuadrupleArrow downTipLeftArrow downTipRightArrow drachma dze-cy dzeabkhasian-cy dzhe-cy dzzhe-cy e e-cy eacute earthTrigram ebreve ecaron ecircumflex edieresis edieresis-cy edotaccent ef-cy egrave eight eight.dnom eight.numr eight.tosf eightinferior eightsuperior eiotified-cy ejectsymbol el-cy eldescender-cy element elementSmall elhook-cy ellipsis elmiddlehook-cy eltail-cy em-cy emacron emdash emdash.case emptyset emtail-cy en-cy endOfMedium-control endOfText-control endOfTransmission-control endOfTransmissionBlock-control endash endash.case endescender-cy endofproof eng enghe-cy enhook-cy enlefthook-cy enmiddlehook-cy enquiry-control entail-cy eogonek epsilon epsilonLunateReversedSymbol epsilonLunateSymbol epsilondasia epsilondasiaoxia epsilondasiavaria epsilonoxia epsilonpsili epsilonpsilioxia epsilonpsilivaria epsilontonos epsilonvaria equal equal.dnom equal.numr equal.spacer equal_asciitilde.ss07 equal_end.seq equal_equal.liga equal_equal.ss08 equal_equal_equal.liga equal_equal_equal.ss08 equal_middle.seq equal_start.seq equals.circled equalsinferior equalsuperior equivalence er-cy ereversed-cy ertick-cy es-cy escape-control esdescender-cy estimated eta etadasia etadasiaoxia etadasiaoxiaypogegrammeni etadasiaperispomeni etadasiaperispomeniypogegrammeni etadasiavaria etadasiavariaypogegrammeni etadasiaypogegrammeni etaoxia etaoxiaypogegrammeni etaperispomeni etaperispomeniypogegrammeni etapsili etapsilioxia etapsilioxiaypogegrammeni etapsiliperispomeni etapsiliperispomeniypogegrammeni etapsilivaria etapsilivariaypogegrammeni etapsiliypogegrammeni etatonos etavaria etavariaypogegrammeni etaypogegrammeni eth euro exclam exclam.spacer exclam_asciitilde.ss07 exclam_equal.liga exclam_equal.ss08 exclam_equal_equal.liga exclam_equal_equal.ss08 exclam_equal_middle.seq exclam_exclam.liga exclam_exclam_period.liga exclamdown exclamdown.case existential f f.spacer f_i.liga.ss10 f_j.liga.ss10 f_l.liga.ss10 f_t.liga.ss10 female figuredash fileSeparator-control filledRect filledbox fireTrigram firsttonechinese fisheye fita-cy five five.dnom five.numr five.tosf fiveeighths fiveinferior fivesixths fivesuperior florin forces formFeed-control four four.dnom four.numr four.tosf fourfifths fourinferior foursuperior fraction fullBlock g g.cv02 gamma gbreve gbreve.cv02 gcircumflex gcircumflex.cv02 gcommaaccent gcommaaccent.cv02 gdotaccent gdotaccent.cv02 ge-cy gedescender-cy germandbls gestrokehook-cy ghemiddlehook-cy ghestroke-cy gheupturn-cy gje-cy globeWithMeridians gradient grave grave.case gravecomb greater greater.center greater.spacer greater_equal.liga greater_equal.ss02 greater_equal_end.seq greater_equal_middle.seq greater_equal_start.seq greater_greater.liga greater_greater_equal_end.seq greater_greater_equal_middle.seq greater_greater_equal_start.seq greater_greater_greater.liga greater_greater_hyphen_end.seq greater_greater_hyphen_middle.seq greater_greater_hyphen_start.seq greater_hyphen_end.seq greater_hyphen_middle.seq greater_hyphen_start.seq greaterequal groupSeparator-control guillemetleft guillemetleft.case guillemetright guillemetright.case guilsinglleft guilsinglleft.case guilsinglright guilsinglright.case h ha-cy haabkhasian-cy hadescender-cy hahook-cy hardsign-cy hastroke-cy hbar hcircumflex heart heavenTrigram heavyleftpointinganglebracketornament heavyrightpointinganglebracketornament helmsymbol heta horizontalFillSquare horizontalTabulation-control house hungarumlaut hungarumlaut.case hungarumlautcomb hyphen hyphen.case hyphen.lc hyphen.spacer hyphen_asciitilde.liga hyphen_end.seq hyphen_hyphen.liga hyphen_middle.seq hyphen_start.seq i i-cy i.cv03 i.cv04 i.cv05 i.cv06 i.salt_low ia-cy iacute iacute.cv03 iacute.cv04 iacute.cv05 iacute.cv06 ibreve ibreve.cv03 ibreve.cv04 ibreve.cv05 ibreve.cv06 icircumflex icircumflex.cv03 icircumflex.cv04 icircumflex.cv05 icircumflex.cv06 idieresis idieresis-cy idieresis.cv03 idieresis.cv04 idieresis.cv05 idieresis.cv06 idotaccent idotaccent.cv03 idotaccent.cv04 idotaccent.cv05 idotaccent.cv06 idotless idotless.cv03 idotless.cv04 idotless.cv05 idotless.cv06 ie-cy iebreve-cy iegrave-cy igrave igrave.cv03 igrave.cv04 igrave.cv05 igrave.cv06 ii-cy iigrave-cy iishort-cy iishorttail-cy ij imacron imacron-cy imacron.cv03 imacron.cv04 imacron.cv05 imacron.cv06 increment infinity infinity.case integral integralbt integraltp intersection inverseWhiteCircle invsmileface io-cy iogonek iogonek.cv03 iogonek.cv04 iogonek.cv05 iogonek.cv06 iota iotadasia iotadasiaoxia iotadasiaperispomeni iotadasiavaria iotadialytikaoxia iotadialytikaperispomeni iotadialytikavaria iotadieresis iotadieresistonos iotamacron iotaoxia iotaperispomeni iotapsili iotapsilioxia iotapsiliperispomeni iotapsilivaria iotatonos iotavaria iotavrachy itilde itilde.cv03 itilde.cv04 itilde.cv05 itilde.cv06 iu-cy izhitsa-cy izhitsadblgrave-cy j j.salt_low jcircumflex je-cy k ka-cy kabashkir-cy kadescender-cy kahook-cy kaiSymbol kappa kappaSymbol kastroke-cy kaverticalstroke-cy kcommaaccent keyboard kgreenlandic kje-cy komide-cy komidje-cy komidzje-cy komilje-cy kominje-cy komisje-cy komitje-cy komizje-cy koppa koppaArchaic koronis ksi-cy l l.cv07 l.cv08 l.cv09 l.cv10 l.salt_low l.spacer lacute lacute.cv07 lacute.cv08 lacute.cv09 lacute.cv10 lakeTrigram lambda largeCircle lcaron lcaron.cv07 lcaron.cv08 lcaron.cv09 lcaron.cv10 lcommaaccent lcommaaccent.cv07 lcommaaccent.cv08 lcommaaccent.cv09 lcommaaccent.cv10 ldot ldot.cv07 ldot.cv08 ldot.cv09 ldot.cv10 leftBlackArrow leftBlackTriangle leftBlock leftFiveEighthsBlock leftHalfBlackCircle leftHalfBlackSquare leftHalfBlackWhiteCircle leftHookArrow leftLongArrow leftLongDoubleArrow leftLongDoubleFromBarArrow leftLongFromBarArrow leftOneEighthBlock leftOneQuarterBlock leftRightLongArrow leftRightLongDoubleArrow leftSevenEighthsBlock leftTabArrow leftThreeEighthsBlock leftThreeQuartersBlock leftanglebracket-math leftcurlybracketlowerhook leftcurlybracketmiddlepiece leftcurlybracketupperhook leftsquarebracketextension leftsquarebracketlowercorner leftsquarebracketuppercorner less less.center less.spacer less_asciitilde.liga less_asciitilde_asciitilde.liga less_asciitilde_greater.liga less_asterisk.liga less_asterisk.liga.cv16 less_asterisk_greater.liga less_asterisk_greater.liga.cv16 less_bar.liga less_bar_bar.liga less_bar_bar_bar.liga less_bar_greater.liga less_dollar.liga less_dollar.liga.ss04 less_dollar_greater.liga less_dollar_greater.liga.ss04 less_equal.liga less_equal.ss02 less_equal_end.seq less_equal_middle.seq less_equal_start.seq less_exclam_hyphen_hyphen.liga less_greater.liga less_hyphen_end.seq less_hyphen_middle.seq less_hyphen_start.seq less_less.liga less_less_equal_end.seq less_less_equal_middle.seq less_less_equal_start.seq less_less_hyphen_end.seq less_less_hyphen_middle.seq less_less_hyphen_start.seq less_less_less.liga less_plus.liga less_plus_greater.liga less_slash.liga less_slash_greater.liga lessequal lha-cy lineFeed-control liraTurkish literSign lje-cy logicaland logicalnot logicalor lowerFiveEighthsBlock lowerHalfArc lowerHalfBlackWhiteCircle lowerHalfInverseWhiteCircle lowerLeftArc lowerLeftQuadrantWhiteCircle lowerOneEighthBlock lowerOneQuarterBlock lowerRightArc lowerRightDiagonalHalfBlackSquare lowerRightQuadrantWhiteCircle lowerSevenEighthsBlock lowerThreeEighthsBlock lowerThreeQuartersBlock lowernumeral-greek lozenge lslash lslash.cv07 lslash.cv08 lslash.cv09 lslash.cv10 ltshade m macron macron.case macroncomb male micro minus minus.dnom minus.numr minusinferior minussuperior minustilde models mountainTrigram mu multiply musicalnote musicalnotedbl n nacute nacute.loclPLK napostrophe ncaron ncommaaccent negateddoubleverticalbardoublerightturnstile negativeAcknowledge-control neitherapproximatelynoractuallyequalto neitherasubsetofnorequalto neitherasupersetofnorequalto newline-control nine nine.dnom nine.numr nine.tosf nineinferior ninesuperior nje-cy nmod notalmostequalto notasymptoticallyequalto notcontains notelement notequal notidentical notsimilar notsubset notsuperset nottrue ntilde nu null null-control numbersign numbersign.spacer numbersign_braceleft.liga numbersign_braceleft.liga.cv29 numbersign_bracketleft.liga numbersign_colon.liga numbersign_colon.liga_rem numbersign_end.seq numbersign_equal.liga numbersign_exclam.liga numbersign_middle.seq numbersign_parenleft.liga numbersign_question.liga numbersign_start.seq numbersign_underscore.liga numbersign_underscore_parenleft.liga numeral-greek numero o o-cy oacute oacute.loclPLK obarred-cy obarreddieresis-cy obreve ocircumflex odieresis odieresis-cy oe ogonek ograve ohungarumlaut omacron omega omega-cy omegadasia omegadasiaoxia omegadasiaoxiaypogegrammeni omegadasiaperispomeni omegadasiaperispomeniypogegrammeni omegadasiavaria omegadasiavariaypogegrammeni omegadasiaypogegrammeni omegaoxia omegaoxiaypogegrammeni omegaperispomeni omegaperispomeniypogegrammeni omegapsili omegapsilioxia omegapsilioxiaypogegrammeni omegapsiliperispomeni omegapsiliperispomeniypogegrammeni omegapsilivaria omegapsilivariaypogegrammeni omegapsiliypogegrammeni omegatonos omegavaria omegavariaypogegrammeni omegaypogegrammeni omicron omicrondasia omicrondasiaoxia omicrondasiavaria omicronoxia omicronpsili omicronpsilioxia omicronpsilivaria omicrontonos omicronvaria one one.dnom one.numr one.tosf oneeighth onefifth onefraction onehalf oneinferior onequarter onesixth onesuperior onethird optionKey ordfeminine ordmasculine oslash oslashacute otilde overlinecomb oxia oxia.case p pagedown pageup palochka-cy pamphyliandigamma paragraph parenleft parenleft.case parenleft.cv31 parenleft.dnom parenleft.numr parenleft.spacer parenleftextension parenleftinferior parenleftlowerhook parenleftsuperior parenleftupperhook parenright parenright.case parenright.cv31 parenright.dnom parenright.numr parenrightextension parenrightinferior parenrightlowerhook parenrightsuperior parenrightupperhook partialdiff pe-cy pedescender-cy pemiddlehook-cy percent percent.cv18 percent.spacer percent_percent.liga percent_percent.liga.cv18 period period.spacer period_equal.cv32 period_hyphen.cv25 period_period.liga period_period_equal.liga period_period_less.liga period_period_period.liga period_question.liga periodcentered perispomeni perispomenicomb perspective perthousand perthousand.cv18 phi phiSymbol pi piSymbol plus plus.dnom plus.lc plus.numr plus.spacer plus_greater.liga plus_plus.liga plus_plus_plus.liga plusinferior plusminus plussuperior primemod product projective propellor proportion prosgegrammeni psi psi-cy psili psilioxia psiliperispomeni psilivaria q qa-cy quadrantLowerLeft quadrantLowerRight quadrantUpperLeft quadrantUpperLeftAndLowerLeftAndLowerRight quadrantUpperLeftAndLowerRight quadrantUpperLeftAndUpperRightAndLowerLeft quadrantUpperLeftAndUpperRightAndLowerRight quadrantUpperRight quadrantUpperRightAndLowerLeft quadrantUpperRightAndLowerLeftAndLowerRight question question.spacer question_equal.liga question_period.liga question_question.liga questiondown questiondown.case questiongreek quotedbl quotedblbase quotedblleft quotedblright quoteleft quoteright quotesinglbase quotesingle r r.ss01 racute radical ratio rcaron rcommaaccent recordSeparator-control reflexsubset reflexsuperset registered replacementCharacter returnsymbol reverseddottedlunatesigmasymbol reversedlunatesigmasymbol reversedze-cy revlogicalnot rha-cy rho rhoStrokeSymbol rhoSymbol rhodasia rhopsili rightBlackTriangle rightBlock rightCircledPlusArrow rightHalfBlackCircle rightHalfBlackSquare rightHalfBlackWhiteCircle rightHookArrow rightLongDoubleArrow rightLongDoubleFromBarArrow rightLongFromBarArrow rightLongSquiggleArrow rightOneEighthBlock rightTabArrow rightanglebracket-math rightcurlybracketlowerhook rightcurlybracketmiddlepiece rightcurlybracketupperhook rightlongArrow rightsquarebracketextension rightsquarebracketlowercorner rightsquarebracketuppercorner righttack ring ring.case ringcomb ruble rupeeIndian s sacute sacute.loclPLK sampi san scaron scedilla schwa-cy schwadieresis-cy scircumflex scommaaccent section semicolon semicolon.spacer semicolon_semicolon.liga semisoftsign-cy seven seven.dnom seven.numr seven.tosf seveneighths seveninferior sevensuperior sha-cy shade shcha-cy shha-cy shhadescender-cy shiftIn-control shiftOut-control sho sigma sigmaLunateSymbol sigmafinal six six.dnom six.numr six.tosf sixinferior sixsuperior skullAndCrossbones slash slash.spacer slash_asterisk.liga slash_asterisk.liga.cv16 slash_backslash.liga slash_equal_end.seq slash_equal_middle.seq slash_equal_start.seq slash_greater.liga slash_slash.liga slash_slash_equal_end.seq slash_slash_equal_middle.seq slash_slash_equal_start.seq slash_slash_slash.liga smileface softhyphen softhyphen.case softsign-cy space-control spade squarewhitewithsmallblack startOfHeading-control startOfText-control sterling stigma strokelongoverlay strokeshortoverlay subset subsetnotequal substitute-control substituteFormTwo-control suchthat summation sun superset supersetnotequal synchronousIdle-control t tackdown tackleft tau tbar tcaron tcedilla tcommaaccent te-cy tedescender-cy tetse-cy theredoesnotexist therefore theta thetaSymbol thorn three three.cv14 three.cv14.dnom three.cv14.numr three.dnom three.dnom.cv14 three.numr three.numr.cv14 three.tosf three.tosf.cv14 threeTurned threeeighths threeemdash threefifths threeinferior threeinferior.cv14 threequarters threesuperior threesuperior.cv14 thunderTrigram tilde tilde.case tildecomb tironiansignet tonos tonos.case trademark triaglf triagupTriangle triangledown triangleright tripletilde tripleverticalbarrightturnstile true tse-cy tshe-cy two two.dnom two.numr two.tosf twoTurned twoemdash twofifths twoinferior twosuperior twothirds u u-cy u1F10D u1F10E u1F10F u1F16D u1F16E u1F16F u1F1AD uacute ubreve ucircumflex udieresis udieresis-cy ugrave uhungarumlaut uhungarumlaut-cy uk-cy umacron umacron-cy underscore underscore.spacer underscore_end.seq underscore_middle.seq underscore_start.seq underscoredbl uni256D uni256E uni256F uni2570 uniE000 uniE001 uniE002 uniE003 uniE0A0 uniE0A1 uniE0A2 uniE0B0 uniE0B1 uniE0B2 uniE0B3 uniEE00 uniEE01 uniEE02 uniEE03 uniEE04 uniEE05 uniEE06 uniEE07 uniEE08 uniEE09 uniEE0A uniEE0B uniFEFF union unitSeparator-control universal uogonek upBetweenTwoHorizontalBarsArrowHead upBlackArrow upBlock upQuadrupleArrow upTipLeftArrow upTipRightArrow upperHalfArc upperHalfBlackWhiteCircle upperHalfInverseWhiteCircle upperLeftArc upperLeftDiagonalHalfBlackSquare upperLeftQuadrantWhiteCircle upperLeftWhiteCircle upperOneEighthBlock upperRightArc upperRightQuadrantWhiteCircle upperlefttolowerrightFillSquare upperrighttolowerleftFillSquare upsilon upsilondasia upsilondasiaoxia upsilondasiaperispomeni upsilondasiavaria upsilondialytikaoxia upsilondialytikaperispomeni upsilondialytikavaria upsilondieresis upsilondieresistonos upsilonmacron upsilonoxia upsilonperispomeni upsilonpsili upsilonpsilioxia upsilonpsiliperispomeni upsilonpsilivaria upsilontonos upsilonvaria upsilonvrachy uptack uring ushort-cy ustrait-cy ustraitstroke-cy utilde v varia varia.case ve-cy verticalBisectingLineWhiteSquare verticalFillSquare verticalTabulation-control w w.spacer w_w_w.liga wacute waterTrigram wcircumflex wdieresis we-cy wgrave whiteCircle whiteDiamond whiteFrowningFace whiteRect whiteSquareWithLowerLeftQuadrant whiteSquareWithLowerRightQuadrant whiteSquareWithRoundedCorners whiteSquareWithUpperLeftQuadrant whiteSquareWithUpperRightQuadrant whiteVerticalRect windTrigram x x.multiply x.multiply.tosf xi y yacute yae-cy yat-cy ycircumflex ydieresis yen yeru-cy yerudieresis-cy ygrave yi-cy yot ypogegrammeni ypogegrammenicomb yusbig-cy yusbigiotified-cy yuslittle-cy yuslittleiotified-cy z zacute zacute.loclPLK zcaron zdotaccent ze-cy zedescender-cy zedieresis-cy zero zero.cv11 zero.cv12 zero.cv13 zero.dnom zero.numr zero.tosf zero.tosf.cv11 zero.tosf.cv12 zero.tosf.cv13 zero.tosf.zero zero.zero zero.zero.tosf zeroinferior zerosuperior zeta zhe-cy zhebreve-cy zhedescender-cy zhedieresis-cy";
@@ -119779,6 +119782,182 @@ width = 1200;
 }
 );
 unicode = 1FB7B;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = leftAndLowerOneEighthBlock;
+lastChange = "2023-12-31 14:00:58 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 -600 LINE",
+"1200 -600 LINE",
+"1200 -300 LINE",
+"150 -300 LINE",
+"150 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 -600 LINE",
+"1200 -600 LINE",
+"1200 -300 LINE",
+"150 -300 LINE",
+"150 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB7C;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = leftAndUpperOneEighthBlock;
+lastChange = "2023-12-31 14:02:22 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 -600 LINE",
+"150 -600 LINE",
+"150 1500 LINE",
+"1200 1500 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 -600 LINE",
+"150 -600 LINE",
+"150 1500 LINE",
+"1200 1500 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB7D;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = rightAndLowerOneEighthBlock;
+lastChange = "2023-12-31 14:04:49 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"1050 1800 LINE",
+"1050 -300 LINE",
+"0 -300 LINE",
+"0 -600 LINE",
+"1200 -600 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"1050 1800 LINE",
+"1050 -300 LINE",
+"0 -300 LINE",
+"0 -600 LINE",
+"1200 -600 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB7F;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = rightAndUpperOneEighthBlock;
+lastChange = "2023-12-31 14:04:48 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 1500 LINE",
+"1050 1500 LINE",
+"1050 -600 LINE",
+"1200 -600 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 1500 LINE",
+"1050 1500 LINE",
+"1050 -600 LINE",
+"1200 -600 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB7E;
 category = Symbol;
 subCategory = Geometry;
 },

--- a/FiraCode.glyphs
+++ b/FiraCode.glyphs
@@ -509,7 +509,6 @@ id = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
 verticalStems = (
 124
 );
-visible = 1;
 weight = Light;
 weightValue = 62;
 xHeight = 1050;
@@ -578,6 +577,7 @@ id = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
 verticalStems = (
 316
 );
+visible = 1;
 weight = Bold;
 weightValue = 158;
 xHeight = 1062;
@@ -119760,6 +119760,286 @@ width = 1200;
 );
 note = uni2570;
 unicode = 2570;
+},
+{
+color = 3;
+glyphname = upperOneQuarterBlock;
+lastChange = "2023-12-31 11:47:14 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 1500 LINE",
+"1200 1500 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"0 1800 LINE",
+"0 1200 LINE",
+"1200 1200 LINE",
+"1200 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB82;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = "verticalOneEighthBlock-2";
+lastChange = "2023-12-31 13:35:29 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"150 1800 LINE",
+"150 -600 LINE",
+"300 -600 LINE",
+"300 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"150 1800 LINE",
+"150 -600 LINE",
+"300 -600 LINE",
+"300 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB70;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = "verticalOneEighthBlock-3";
+lastChange = "2023-12-31 13:36:01 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"300 1800 LINE",
+"300 -600 LINE",
+"450 -600 LINE",
+"450 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"300 1800 LINE",
+"300 -600 LINE",
+"450 -600 LINE",
+"450 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB71;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = "verticalOneEighthBlock-4";
+lastChange = "2023-12-31 13:36:19 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"450 1800 LINE",
+"450 -600 LINE",
+"600 -600 LINE",
+"600 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"450 1800 LINE",
+"450 -600 LINE",
+"600 -600 LINE",
+"600 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB72;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = "verticalOneEighthBlock-5";
+lastChange = "2023-12-31 13:36:36 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"600 1800 LINE",
+"600 -600 LINE",
+"750 -600 LINE",
+"750 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"600 1800 LINE",
+"600 -600 LINE",
+"750 -600 LINE",
+"750 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB73;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = "verticalOneEighthBlock-6";
+lastChange = "2023-12-31 13:36:50 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"750 1800 LINE",
+"750 -600 LINE",
+"900 -600 LINE",
+"900 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"750 1800 LINE",
+"750 -600 LINE",
+"900 -600 LINE",
+"900 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB74;
+category = Symbol;
+subCategory = Geometry;
+},
+{
+color = 3;
+glyphname = "verticalOneEighthBlock-7";
+lastChange = "2023-12-31 13:37:02 +0000";
+layers = (
+{
+layerId = "4B7A3BAF-EAD8-4024-9BEA-BB1DE86CFCFA";
+paths = (
+{
+closed = 1;
+nodes = (
+"900 1800 LINE",
+"900 -600 LINE",
+"1050 -600 LINE",
+"1050 1800 LINE"
+);
+}
+);
+width = 1200;
+},
+{
+layerId = "B67F0F2D-EC95-4CB8-966E-23AE86958A69";
+paths = (
+{
+closed = 1;
+nodes = (
+"900 1800 LINE",
+"900 -600 LINE",
+"1050 -600 LINE",
+"1050 1800 LINE"
+);
+}
+);
+width = 1200;
+}
+);
+unicode = 1FB75;
+category = Symbol;
+subCategory = Geometry;
 },
 {
 color = 3;

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: build
 
 build:
-	docker run --rm -v ${PWD}:/opt tonsky/firacode:latest ./script/build.sh
+	docker run --rm -v ${PWD}:/opt tonsky/firacode:latest ./script/build.sh -w Retina
 
 package:
 	./script/package.sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: build
 
 build:
-	docker run --rm -v ${PWD}:/opt tonsky/firacode:latest ./script/build.sh -w Retina
+	docker run --rm -v ${PWD}:/opt tonsky/firacode:latest ./script/build.sh
 
 package:
 	./script/package.sh


### PR DESCRIPTION
1FB70 to 1FB8B inclusive (28 glyphs of 212 total in the block)

<img width="353" alt="image" src="https://github.com/tonsky/FiraCode/assets/381361/8d7902f4-9d97-4926-9d79-7f0591c47989"> <img width="354" alt="image" src="https://github.com/tonsky/FiraCode/assets/381361/1ebecbf6-715d-4053-8c54-1f167521701f">

This is my first font editing experience, so I'm sure I've probably messed something up. In particular, I think at least one of the glyphs I duplicated and edited the original rather than the duplicate. I think this explains the removals in the diff


Issues I ran into (notes for others following a similar path):
- The latest version of glyphs mini is later than the current glyph file, so any edit make a bunch of extra edits to the file. You can find the download that matches by checking homebrew history. https://github.com/Homebrew/homebrew-cask/commit/c18f1f547a9e9c768ef0312ed02ef31f70042c42 -> https://updates.glyphsapp.com/Glyphs3.0.4-3108.zip
- Don't accidentally open the TTF in glyphs mini when trying install it, and then do a bunch of work on all the glyphs and then close the ttf and lose it all. That really blows :D
- ran into intermitten problems running the docker image. Usually running `git clean -f` got me past the problem though.
- That glyphs file format would be much easier to visually diff if it had indentation 