### PR TITLE
Update macos bootstrap script for macos 13.2.1

### DIFF
--- a/script/bootstrap_macos.sh
+++ b/script/bootstrap_macos.sh
@@ -2,18 +2,17 @@
 set -o errexit -o nounset -o pipefail
 cd "`dirname $0`/.."
 
-sudo easy_install-3.8 pip
-pip install virtualenv --user
-python3 -m virtualenv venv
+brew install python@3.12
+python3.12 -m venv venv
 source venv/bin/activate
 
-# https://github.com/googlefonts/gftools/issues/121
+## https://github.com/googlefonts/gftools/issues/121
 brew install pkg-config
 brew install zlib
-pip install -U Pillow==5.4.1 idna==2.8 requests==2.21.0 urllib3==1.24.1
-export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"
+pip install -U Pillow==8.0.1 idna==2.8 requests==2.21.0 urllib3==1.24.1
+export PKG_CONFIG_PATH="/opt/homebrew/opt/libffi/lib/pkgconfig"
 pip install pycairo
-pip install git+https://github.com/googlefonts/gftools
+pip install gftools
 
 pip install fontmake
 brew install ttfautohint


### PR DESCRIPTION
Tested on macos 13.2.1 (arm).
Generated fonts is okay (features supported).