### PR TITLE
add zed editor to list of compatible editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Unicode coverage makes Fira Code a great choice for mathematical writing:
 | **Xcode** (8.0+, otherwise [with plugin](https://github.com/robertvojta/LigatureXcodePlugin)) |
 | **Xi** |
 | Probably work: **Smultron, Vico** | Under question: **Code::Blocks IDE** |
+| **Zed** ([instructions](https://zed.dev/docs/configuring-zed#buffer-font-family)) | |
 
 ### Terminal compatibility list
 


### PR DESCRIPTION
the fira code font can be used in the [`zed`](https://zed.dev) editor as well. 

To change the font use: 
```json
{
  "buffer_font_family": "Fira Code"
}
```

To enable ligatures: 
```json
{
  "buffer_font_features": {
        "calt": true
  }
}
```