### PR TITLE
Remove malicious webmakerapp.com link

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ code { font-family: 'Fira Code', monospace; }
 - [Klipse](http://app.klipse.tech/)
 - [IlyaBirman.net](http://ilyabirman.net/)
 - [EvilMartians.com](https://evilmartians.com/)
-- [Web Maker](https://webmakerapp.com/)
 - [FromScratch](https://fromscratch.rocks/)
 - [PEP20.org](https://pep20.org/)
 


### PR DESCRIPTION
This PR removes a suspicious external link pointing to webmakerapp.com, which currently redirects through multiple domains and shows a fake virus alert.