### PR TITLE
Fix vertical misalignment of `::` after angle brackets

### DIFF
--- a/FiraCode.glyphs
+++ b/FiraCode.glyphs
@@ -1103,8 +1103,6 @@ lookup colon_colon_colon {
   ignore sub colon colon' colon colon;
   ignore sub colon' colon colon colon;
   ignore sub parenleft question colon' colon colon;
-  ignore sub colon' colon colon [less greater];
-  ignore sub [less greater] colon' colon colon;
   sub colon.spacer colon.spacer colon' by colon_colon_colon.liga;
   sub colon.spacer colon'       colon  by colon.spacer;
   sub colon'       colon        colon  by colon.spacer;
@@ -1365,8 +1363,6 @@ lookup colon_colon {
   ignore sub colon colon' colon;
   ignore sub colon' colon colon;
   ignore sub parenleft question colon' colon;
-  ignore sub colon' colon [less greater];
-  ignore sub [less greater] colon' colon;
   sub colon.spacer colon' by colon_colon.liga;
   sub colon'       colon  by colon.spacer;
 } colon_colon;
@@ -1658,9 +1654,6 @@ lookup center {
     #574 :>= :<=
     ignore sub colon' [less greater] [equal hyphen];
 
-    #1145 ::< ::> <:: >::
-    ignore sub colon colon' [less greater];
-    ignore sub [less greater]' colon colon;
 
     # middles & ends
     sub [less.center greater.center colon.center] colon' by colon.center;

--- a/clojure/fira_code/calt.clj
+++ b/clojure/fira_code/calt.clj
@@ -73,17 +73,6 @@
       "  ignore sub slash asterisk' asterisk asterisk;\n"
       "  ignore sub asterisk' asterisk asterisk slash;\n")
 
-    ;; #1061
-    ["colon" "colon"]
-    (str
-      "  ignore sub colon' colon [less greater];\n"
-      "  ignore sub [less greater] colon' colon;\n")
-
-    ["colon" "colon" "colon"]
-    (str
-      "  ignore sub colon' colon colon [less greater];\n"
-      "  ignore sub [less greater] colon' colon colon;\n")
-
     ;; #621 <||>
     ["less" "bar" "bar"]
     "  ignore sub less' bar bar greater;\n"

--- a/features/calt/center.fea
+++ b/features/calt/center.fea
@@ -11,10 +11,6 @@ lookup center {
     #574 :>= :<=
     ignore sub colon' [less greater] [equal hyphen];
 
-    #1145 ::< ::> <:: >::
-    ignore sub colon colon' [less greater];
-    ignore sub [less greater]' colon colon;
-
     # middles & ends
     sub [less.center greater.center colon.center] colon' by colon.center;
     sub colon.center [less greater]' by [less.center greater.center];


### PR DESCRIPTION
First of all, I'm a complete beginner when it comes to fonts, so I hope I did nothing bad.

The issue was caused by a rule that prevented `::` and `:::` from ligating when adjacent to `<` or `>`. Because the colons were kept separate, the second colon was independantly shifted upwards to align with the following uppercase letter, while leaving the first colon on the baseline.

By removing the `ignore sub` rules for colons next to angle brackets, `::` now properly forms a single `colon_colon.liga` unit.

This fixes #1684, #1329 and #1225